### PR TITLE
Handle lane_ids in workflow the workflow service

### DIFF
--- a/spec/workflow_service_spec.rb
+++ b/spec/workflow_service_spec.rb
@@ -181,18 +181,18 @@ describe Dor::WorkflowService do
 
     context "a query with one step completed and one waiting" do
       it "creates the URI string with only the one completed step" do
-        @mock_resource.should_receive(:[]).with("workflow_queue?waiting=#{@repository}:#{@workflow}:#{@waiting}&completed=#{@repository}:#{@workflow}:#{@completed}")
+        @mock_resource.should_receive(:[]).with("workflow_queue?waiting=#{@repository}:#{@workflow}:#{@waiting}&completed=#{@repository}:#{@workflow}:#{@completed}&lane-id=default")
         @mock_resource.should_receive(:get).and_return(%{<objects count="1"><object id="druid:ab123de4567"/><object id="druid:ab123de9012"/></objects>})
-        Dor::WorkflowService.get_objects_for_workstep(@completed, @waiting, @repository, @workflow).should == ['druid:ab123de4567','druid:ab123de9012']
+        Dor::WorkflowService.get_objects_for_workstep(@completed, @waiting, 'default', :default_repository => @repository, :default_workflow => @workflow).should == ['druid:ab123de4567','druid:ab123de9012']
       end
     end
 
     context "a query with TWO steps completed and one waiting" do
       it "creates the URI string with the two completed steps correctly" do
         second_completed="google-convert"
-        @mock_resource.should_receive(:[]).with("workflow_queue?waiting=#{@repository}:#{@workflow}:#{@waiting}&completed=#{@repository}:#{@workflow}:#{@completed}&completed=#{@repository}:#{@workflow}:#{second_completed}")
+        @mock_resource.should_receive(:[]).with("workflow_queue?waiting=#{@repository}:#{@workflow}:#{@waiting}&completed=#{@repository}:#{@workflow}:#{@completed}&completed=#{@repository}:#{@workflow}:#{second_completed}&lane-id=default")
         @mock_resource.should_receive(:get).and_return(%{<objects count="1"><object id="druid:ab123de4567"/><object id="druid:ab123de9012"/></objects>})
-        Dor::WorkflowService.get_objects_for_workstep([@completed,second_completed], @waiting, @repository, @workflow).should == ['druid:ab123de4567','druid:ab123de9012']
+        Dor::WorkflowService.get_objects_for_workstep([@completed,second_completed], @waiting, 'default', :default_repository => @repository, :default_workflow => @workflow).should == ['druid:ab123de4567','druid:ab123de9012']
       end
     end
 
@@ -206,7 +206,7 @@ describe Dor::WorkflowService do
         completed3="ingest-transfer"
         qualified_completed2 = "#{repo2}:#{workflow2}:#{completed2}"
         qualified_completed3 = "#{repo2}:#{workflow2}:#{completed3}"
-        @mock_resource.should_receive(:[]).with("workflow_queue?waiting=#{qualified_waiting}&completed=#{qualified_completed}&completed=#{qualified_completed2}&completed=#{qualified_completed3}")
+        @mock_resource.should_receive(:[]).with("workflow_queue?waiting=#{qualified_waiting}&completed=#{qualified_completed}&completed=#{qualified_completed2}&completed=#{qualified_completed3}&lane-id=default")
         @mock_resource.should_receive(:get).and_return(%{<objects count="2"><object id="druid:ab123de4567"/><object id="druid:ab123de9012"/></objects>})
         Dor::WorkflowService.get_objects_for_workstep([qualified_completed, qualified_completed2, qualified_completed3], qualified_waiting).should == ['druid:ab123de4567', 'druid:ab123de9012']
       end
@@ -220,9 +220,9 @@ describe Dor::WorkflowService do
         completed3="ingest-transfer"
         qualified_completed2 = "#{repo2}:#{workflow2}:#{completed2}"
         qualified_completed3 = "#{repo2}:#{workflow2}:#{completed3}"
-        @mock_resource.should_receive(:[]).with("workflow_queue?waiting=#{qualified_waiting}&completed=#{qualified_completed}&completed=#{qualified_completed2}&completed=#{qualified_completed3}")
+        @mock_resource.should_receive(:[]).with("workflow_queue?waiting=#{qualified_waiting}&completed=#{qualified_completed}&completed=#{qualified_completed2}&completed=#{qualified_completed3}&lane-id=lane1")
         @mock_resource.should_receive(:get).and_return(%{<objects count="2"><object id="druid:ab123de4567"/><object id="druid:ab123de9012"/></objects>})
-        Dor::WorkflowService.get_objects_for_workstep([qualified_completed, qualified_completed2, qualified_completed3], qualified_waiting, nil, nil, lane_id: "lane1").should == [ 'druid:ab123de4567', 'druid:ab123de9012']
+        Dor::WorkflowService.get_objects_for_workstep([qualified_completed, qualified_completed2, qualified_completed3], qualified_waiting, "lane1").should == [ 'druid:ab123de4567', 'druid:ab123de9012']
       end
 
       it "creates the URI string with only one completed step passed in as a String" do
@@ -230,7 +230,7 @@ describe Dor::WorkflowService do
         qualified_completed = "#{@repository}:#{@workflow}:#{@completed}"
         repo2 = "sdr"
 
-        @mock_resource.should_receive(:[]).with("workflow_queue?waiting=#{qualified_waiting}&completed=#{qualified_completed}")
+        @mock_resource.should_receive(:[]).with("workflow_queue?waiting=#{qualified_waiting}&completed=#{qualified_completed}&lane-id=default")
         @mock_resource.should_receive(:get).and_return(%{<objects count="1"><object id="druid:ab123de4567"/></objects>})
         Dor::WorkflowService.get_objects_for_workstep(qualified_completed, qualified_waiting).should == ['druid:ab123de4567']
       end
@@ -238,7 +238,7 @@ describe Dor::WorkflowService do
       it "creates the URI string without any completed steps, only waiting" do
         qualified_waiting = "#{@repository}:#{@workflow}:#{@waiting}"
 
-        @mock_resource.should_receive(:[]).with("workflow_queue?waiting=#{qualified_waiting}")
+        @mock_resource.should_receive(:[]).with("workflow_queue?waiting=#{qualified_waiting}&lane-id=default")
         @mock_resource.should_receive(:get).and_return(%{<objects count="1"><object id="druid:ab123de4567"/></objects>})
         Dor::WorkflowService.get_objects_for_workstep(nil, qualified_waiting).should == ['druid:ab123de4567']
       end
@@ -246,9 +246,9 @@ describe Dor::WorkflowService do
       it "same but with lane_id" do
         qualified_waiting = "#{@repository}:#{@workflow}:#{@waiting}"
 
-        @mock_resource.should_receive(:[]).with("workflow_queue?waiting=#{qualified_waiting}")
+        @mock_resource.should_receive(:[]).with("workflow_queue?waiting=#{qualified_waiting}&lane-id=lane1")
         @mock_resource.should_receive(:get).and_return(%{<objects count="1"><object id="druid:ab123de4567"/></objects>})
-        Dor::WorkflowService.get_objects_for_workstep(nil, qualified_waiting, nil, nil, lane_id: "lane1").should == [ 'druid:ab123de4567' ]
+        Dor::WorkflowService.get_objects_for_workstep(nil, qualified_waiting, "lane1").should == [ 'druid:ab123de4567' ]
       end
     end
   end
@@ -259,9 +259,9 @@ describe Dor::WorkflowService do
       workflow = "googleScannedBookWF"
       completed = "google-download"
       waiting = "process-content"
-      @mock_resource.should_receive(:[]).with("workflow_queue?waiting=#{repository}:#{workflow}:#{waiting}&completed=#{repository}:#{workflow}:#{completed}")
+      @mock_resource.should_receive(:[]).with("workflow_queue?waiting=#{repository}:#{workflow}:#{waiting}&completed=#{repository}:#{workflow}:#{completed}&lane-id=default")
       @mock_resource.should_receive(:get).and_return(%{<objects count="0"/>})
-      Dor::WorkflowService.get_objects_for_workstep(completed, waiting, repository, workflow).should == []
+      Dor::WorkflowService.get_objects_for_workstep(completed, waiting, 'default', :default_repository => repository, :default_workflow => workflow).should == []
     end
   end
 


### PR DESCRIPTION
Changes to .create_workflow, .update_workflow_status, and .get_objects_for_workstep to handle lane_id as optional parameter.
