### PR TITLE
Switch update_workflow_error_status to use a non-deprecated endpoint

### DIFF
--- a/lib/dor/workflow/client.rb
+++ b/lib/dor/workflow/client.rb
@@ -41,7 +41,8 @@ module Dor
 
       delegate :create_workflow, :create_workflow_by_name, :update_workflow_status, :workflow_status,
                :workflow_xml, :update_workflow_error_status, :all_workflows_xml, :workflows,
-               :workflow, :delete_workflow, :delete_all_workflows, :update_status, to: :workflow_routes
+               :workflow, :delete_workflow, :delete_all_workflows, :update_status, :update_error_status,
+               to: :workflow_routes
 
       delegate :lifecycle, :active_lifecycle, :milestones, to: :lifecycle_routes
 

--- a/spec/workflow/client_spec.rb
+++ b/spec/workflow/client_spec.rb
@@ -169,15 +169,19 @@ RSpec.describe Dor::Workflow::Client do
   describe '#update_workflow_error_status' do
     let(:stubs) do
       Faraday::Adapter::Test::Stubs.new do |stub|
-        stub.put("#{@repo}/objects/#{@druid}/workflows/etdSubmitWF/reader-approval") do |env|
+        stub.put("objects/#{@druid}/workflows/etdSubmitWF/reader-approval") do |env|
           expect(env.body).to match(/status="error" errorMessage="Some exception" errorText="The optional stacktrace"/)
-          [201, {}, '']
+          [201, {}, '{"next_steps":["submit-marc"]}']
         end
 
-        stub.put("#{@repo}/objects/#{@druid}/workflows/errorWF/reader-approval") do |_env|
+        stub.put("objects/#{@druid}/workflows/errorWF/reader-approval") do |_env|
           [400, {}, '']
         end
       end
+    end
+
+    before do
+      allow(Deprecation).to receive(:warn)
     end
 
     it 'should update workflow status to error and return true if successful' do


### PR DESCRIPTION
Added update_error_status to replace update_workflow_error_status without having to pass an empty first argument

Fixes #125