### PR TITLE
Deprecate workflow_xml

### DIFF
--- a/spec/workflow/client/workflow_routes_spec.rb
+++ b/spec/workflow/client/workflow_routes_spec.rb
@@ -7,6 +7,30 @@ RSpec.describe Dor::Workflow::Client::WorkflowRoutes do
 
   let(:routes) { described_class.new(requestor: mock_requestor) }
 
+  describe '#fetch_workflow' do
+    subject(:fetch_workflow) { routes.send(:fetch_workflow, druid: 'druid:mw971zk1113', workflow: workflow) }
+
+    context 'when a workflow name is provided' do
+      let(:workflow) { 'etdSubmitWF' }
+      let(:mock_requestor) { instance_double(Dor::Workflow::Client::Requestor, request: xml) }
+      let(:xml) { '<workflow id="etdSubmitWF"><process name="registrar-approval" status="completed" /></workflow>' }
+
+      it 'returns the xml for a given repository, druid, and workflow' do
+        expect(fetch_workflow).to eq(xml)
+        expect(mock_requestor).to have_received(:request)
+          .with('objects/druid:mw971zk1113/workflows/etdSubmitWF')
+      end
+    end
+
+    context 'when no workflow name is provided' do
+      let(:workflow) { nil }
+
+      it 'raises an error' do
+        expect { fetch_workflow }.to raise_error ArgumentError
+      end
+    end
+  end
+
   describe '#workflow' do
     let(:xml) do
       <<~XML
@@ -17,7 +41,7 @@ RSpec.describe Dor::Workflow::Client::WorkflowRoutes do
     end
 
     before do
-      allow(routes).to receive(:workflow_xml) { xml }
+      allow(routes).to receive(:fetch_workflow) { xml }
     end
 
     it 'returns a workflow' do

--- a/spec/workflow/client_spec.rb
+++ b/spec/workflow/client_spec.rb
@@ -336,10 +336,10 @@ RSpec.describe Dor::Workflow::Client do
   end
 
   describe '#workflow_xml' do
+    before do
+      allow(Deprecation).to receive(:warn)
+    end
     context 'with positional args' do
-      before do
-        allow(Deprecation).to receive(:warn)
-      end
       subject(:workflow_xml) { client.workflow_xml('dor', 'druid:123', workflow) }
 
       context 'when a workflow name is provided' do
@@ -371,9 +371,6 @@ RSpec.describe Dor::Workflow::Client do
 
       context 'when a repo is provided' do
         subject(:workflow_xml) { client.workflow_xml(repo: 'dor', druid: 'druid:123', workflow: workflow) }
-        before do
-          allow(Deprecation).to receive(:warn)
-        end
 
         let(:workflow) { 'etdSubmitWF' }
         let(:xml) { '<workflow id="etdSubmitWF"><process name="registrar-approval" status="completed" /></workflow>' }


### PR DESCRIPTION
Nothing in DLSS uses this so it doesn't need to be a public method