### PR TITLE
Raise `Dor::MissingWorkflow` when workflow service returns 404

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,5 +9,4 @@ gem 'activesupport', ENV['RAILS_VERSION'] if ENV['RAILS_VERSION']
 
 group :development, :test do
   gem 'byebug'
-  gem 'simplecov'
 end

--- a/lib/dor/missing_workflow.rb
+++ b/lib/dor/missing_workflow.rb
@@ -1,6 +1,0 @@
-# frozen_string_literal: true
-
-module Dor
-  class MissingWorkflow < WorkflowException
-  end
-end

--- a/lib/dor/missing_workflow.rb
+++ b/lib/dor/missing_workflow.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Dor
+  class MissingWorkflow < WorkflowException
+  end
+end

--- a/lib/dor/missing_workflow_exception.rb
+++ b/lib/dor/missing_workflow_exception.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module Dor
+  class MissingWorkflowException < WorkflowException
+  end
+end

--- a/lib/dor/workflow_exception.rb
+++ b/lib/dor/workflow_exception.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module Dor
-  class WorkflowException < ::RuntimeError
+  class WorkflowException < RuntimeError
   end
 end

--- a/spec/workflow/client_spec.rb
+++ b/spec/workflow/client_spec.rb
@@ -329,8 +329,16 @@ RSpec.describe Dor::Workflow::Client do
       end
     end
 
-    context 'when it fails for any reason' do
+    context 'when the status is not found' do
       let(:status) { 404 }
+
+      it 'throws the missing workflow exception' do
+        expect { subject }.to raise_error Dor::MissingWorkflowException
+      end
+    end
+
+    context 'when it fails with status other than 404' do
+      let(:status) { 422 }
 
       it 'throws an exception' do
         expect { subject }.to raise_error Dor::WorkflowException


### PR DESCRIPTION
Refs sul-dlss/workflow-server-rails#297

Add `Dor::MissingWorkflow` exception as subclass of Dor::WorkflowException so existing code can continue to rescue `Dor::MissingWorkflow` without changing code downstream.

Also includes the following opportunistic work:
* Remove redundant simplecov dependency
* Remove (apparently) unnecessary explicit scoping for RuntimeError



