### PR TITLE
Provide a way to get all errors for a version

### DIFF
--- a/lib/dor/workflow/response/workflows.rb
+++ b/lib/dor/workflow/response/workflows.rb
@@ -19,6 +19,12 @@ module Dor
           end
         end
 
+        # @return [Array<String>] returns a list of errors for any process for the current version
+        def errors_for(version:)
+          ng_xml.xpath("//workflow/process[@version='#{version}' and @status='error']/@errorMessage")
+                .map(&:text)
+        end
+
         attr_reader :xml
 
         private

--- a/spec/models/response/workflows_spec.rb
+++ b/spec/models/response/workflows_spec.rb
@@ -36,4 +36,27 @@ RSpec.describe Dor::Workflow::Response::Workflows do
       expect(subject.map(&:workflow_name)).to eq %w[assemblyWF sdrPreservationWF]
     end
   end
+
+  describe '#errors_for' do
+    subject { instance.errors_for(version: 2) }
+
+    let(:xml) do
+      <<~XML
+        <workflows objectId="druid:mw971zk1113">
+          <workflow repository="dor" objectId="druid:mw971zk1113" id="assemblyWF">
+            <process version="1" status="error" errorMessage="err1" />
+            <process version="2" status="error" errorMessage="err2" />
+            <process version="2" status="complete" errorMessage="err3" />
+          </workflow>
+          <workflow repository="dor" objectId="druid:mw971zk1113" id="sdrPreservationWF">
+            <process version="1" status="error" errorMessage="err4" />
+            <process version="2" status="error" errorMessage="err5" />
+            <process version="2" status="complete" errorMessage="err6" />
+          </workflow>
+        </workflows>
+      XML
+    end
+
+    it { is_expected.to eq %w[err2 err5] }
+  end
 end


### PR DESCRIPTION
This will help dor-services-app answer 'are there any errors' without needing to know the implementation.
See: https://github.com/sul-dlss/dor-services-app/blob/7fb98f10efb7b14c34077da0160489f87acd3a72/app/services/workflow_error_checking_service.rb#L23-L25