### PR TITLE
Use the non-deprecated route for closing a version

### DIFF
--- a/lib/dor/workflow/client/version_routes.rb
+++ b/lib/dor/workflow/client/version_routes.rb
@@ -14,7 +14,7 @@ module Dor
         # - completes the versioningWF:submit-version and versioningWF:start-accession steps
         # - initiates accesssionWF
         #
-        # @param [String] repo The repository the object resides in.  The service recoginzes "dor" and "sdr" at the moment
+        # @param [String] repo The repository the object resides in. This parameter is deprecated
         # @param [String] druid The id of the object to delete the workflow from
         # @param [Boolean] create_accession_wf Option to create accessionWF when closing a version.  Defaults to true
         # rubocop:disable Metrics/MethodLength
@@ -37,7 +37,9 @@ module Dor
             raise ArgumentError, 'wrong number of arguments, must be 1-3'
           end
 
-          requestor.request(construct_url(repo, druid, version, create_accession_wf), 'post', '')
+          Deprecation.warn(self, 'passing the repo parameter to close_version is no longer necessary. This will raise an error in dor-workflow-client version 4') if repo
+
+          requestor.request(construct_url(druid, version, create_accession_wf), 'post', '')
           true
         end
         # rubocop:enable Metrics/MethodLength
@@ -46,8 +48,8 @@ module Dor
 
         attr_reader :requestor
 
-        def construct_url(repo, druid, version, create_accession_wf)
-          url = "#{repo}/objects/#{druid}/versionClose"
+        def construct_url(druid, version, create_accession_wf)
+          url = "objects/#{druid}/versionClose"
 
           qs_args = []
           qs_args << "version=#{version}" if version

--- a/spec/workflow/client/version_routes_spec.rb
+++ b/spec/workflow/client/version_routes_spec.rb
@@ -19,40 +19,53 @@ RSpec.describe Dor::Workflow::Client::VersionRoutes do
 
       it 'calls the versionClose endpoint with druid' do
         routes.close_version(repo, druid)
-        expect(Deprecation).to have_received(:warn)
+        expect(Deprecation).to have_received(:warn).twice
       end
 
       it 'optionally prevents creation of accessionWF' do
         routes.close_version(repo, druid, false)
         expect(mock_requestor).to have_received(:request)
-          .with('dor/objects/druid:123/versionClose?create-accession=false', 'post', '')
-        expect(Deprecation).to have_received(:warn)
+          .with('objects/druid:123/versionClose?create-accession=false', 'post', '')
+        expect(Deprecation).to have_received(:warn).twice
       end
     end
 
     context 'with kwargs' do
       it 'calls the versionClose endpoint' do
-        routes.close_version(repo: repo, druid: druid)
+        routes.close_version(druid: druid)
         expect(mock_requestor).to have_received(:request)
-          .with('dor/objects/druid:123/versionClose', 'post', '')
+          .with('objects/druid:123/versionClose', 'post', '')
+      end
+
+      context 'with deprecated repo arg' do
+        before do
+          allow(Deprecation).to receive(:warn)
+        end
+
+        it 'calls the versionClose endpoint' do
+          routes.close_version(repo: repo, druid: druid)
+          expect(mock_requestor).to have_received(:request)
+            .with('objects/druid:123/versionClose', 'post', '')
+          expect(Deprecation).to have_received(:warn)
+        end
       end
 
       it 'optionally prevents creation of accessionWF' do
-        routes.close_version(repo: repo, druid: druid, create_accession_wf: false)
+        routes.close_version(druid: druid, create_accession_wf: false)
         expect(mock_requestor).to have_received(:request)
-          .with('dor/objects/druid:123/versionClose?create-accession=false', 'post', '')
+          .with('objects/druid:123/versionClose?create-accession=false', 'post', '')
       end
 
       it 'optionally passes version' do
-        routes.close_version(repo: repo, druid: druid, version: 3)
+        routes.close_version(druid: druid, version: 3)
         expect(mock_requestor).to have_received(:request)
-          .with('dor/objects/druid:123/versionClose?version=3', 'post', '')
+          .with('objects/druid:123/versionClose?version=3', 'post', '')
       end
 
       it 'optionally prevents creation of accessionWF and passes version' do
-        routes.close_version(repo: repo, druid: druid, create_accession_wf: false, version: 3)
+        routes.close_version(druid: druid, create_accession_wf: false, version: 3)
         expect(mock_requestor).to have_received(:request)
-          .with('dor/objects/druid:123/versionClose?version=3&create-accession=false', 'post', '')
+          .with('objects/druid:123/versionClose?version=3&create-accession=false', 'post', '')
       end
     end
   end


### PR DESCRIPTION
also deprecate passing the repo argument to close_version