### PR TITLE
Add a method for extracting status for an object

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ Show a workflow template
 client.workflow_template('etdSubmitWF')
 ```
 
+Get the status of an object
+```ruby
+client.status(druid: 'druid:gv054hp4128', version: '3').display
+#=> "v3 Accessioned"
+```
+
 ## Underlying Clients
 
 This gem currently uses the [Faraday](https://github.com/lostisland/faraday) HTTP client to access the back-end service.  The clients be accessed directly from your `Dor::Workflow::Client` object:

--- a/lib/dor/workflow/client.rb
+++ b/lib/dor/workflow/client.rb
@@ -81,6 +81,10 @@ module Dor
         WorkflowTemplate.new(requestor: requestor)
       end
 
+      def status(druid:, version:)
+        @status ||= Status.new(druid: druid, version: version, lifecycle_routes: lifecycle_routes)
+      end
+
       private
 
       # Among other things, a distinct method helps tests mock default logger

--- a/lib/dor/workflow/client/status.rb
+++ b/lib/dor/workflow/client/status.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+module Dor
+  module Workflow
+    class Client
+      # reveals the status of an object based on the lifecycles
+      class Status
+        # verbiage we want to use to describe an item when it has completed a particular step
+        STATUS_CODE_DISP_TXT = {
+          0 => 'Unknown Status', # if there are no milestones for the current version, someone likely messed up the versioning process.
+          1 => 'Registered',
+          2 => 'In accessioning',
+          3 => 'In accessioning (described)',
+          4 => 'In accessioning (described, published)',
+          5 => 'In accessioning (described, published, deposited)',
+          6 => 'Accessioned',
+          7 => 'Accessioned (indexed)',
+          8 => 'Accessioned (indexed, ingested)',
+          9 => 'Opened'
+        }.freeze
+
+        # milestones from accessioning and the order they happen in
+        STEPS = {
+          'registered' => 1,
+          'submitted' => 2,
+          'described' => 3,
+          'published' => 4,
+          'deposited' => 5,
+          'accessioned' => 6,
+          'indexed' => 7,
+          'shelved' => 8,
+          'opened' => 9
+        }.freeze
+
+        # @param [String] druid the object identifier
+        # @param [String] version the version identifier
+        # @param [LifecycleRoutes] lifecycle_routes the lifecycle client
+        def initialize(druid:, version:, lifecycle_routes:)
+          @druid = druid
+          @version = version
+          @lifecycle_routes = lifecycle_routes
+        end
+
+        # @return [Hash{Symbol => Object}] including :status_code and :status_time
+        def info
+          # if we have an accessioned milestone, this is the last possible step and should be the status regardless of time stamp
+          accessioned_milestones = current_milestones.select { |m| m[:milestone] == 'accessioned' }
+          return { status_code: STEPS['accessioned'], status_time: accessioned_milestones.last[:at].utc.xmlschema } unless accessioned_milestones.empty?
+
+          status_code = 0
+          status_time = nil
+          # for each milestone in the current version, see if it comes at the same time or after the current 'last' step, if so, make it the last and record the date/time
+          current_milestones.each do |m|
+            m_name = m[:milestone]
+            m_time = m[:at].utc.xmlschema
+            next unless STEPS.key?(m_name) && (!status_time || m_time >= status_time)
+
+            status_code = STEPS[m_name]
+            status_time = m_time
+          end
+
+          { status_code: status_code, status_time: status_time }
+        end
+
+        # @param [Boolean] include_time
+        # @return [String] single composed status from status_info
+        def display(include_time: false)
+          status_info_hash = info
+          status_code = status_info_hash[:status_code]
+          status_time = status_info_hash[:status_time]
+
+          # use the translation table to get the appropriate verbage for the latest step
+          result = "v#{version} #{STATUS_CODE_DISP_TXT[status_code]}"
+          result += " #{format_date(status_time)}" if include_time
+          result
+        end
+
+        def milestones
+          @milestones ||= lifecycle_routes.milestones('dor', druid)
+        end
+
+        private
+
+        attr_reader :druid, :version, :lifecycle_routes
+
+        def current_milestones
+          current = []
+          # only get steps that are part of accessioning and part of the current version. That can mean they were archived with the current version
+          # number, or they might be active (no version number).
+          milestones.each do |m|
+            if STEPS.key?(m[:milestone]) && (m[:version].nil? || m[:version] == version)
+              current << m unless m[:milestone] == 'registered' && version.to_i > 1
+            end
+          end
+          current
+        end
+
+        # handles formating utc date/time to human readable
+        # XXX: bad form to hardcode TZ here.
+        def format_date(datetime)
+          d =
+            if datetime.is_a?(Time)
+              datetime
+            else
+              DateTime.parse(datetime).in_time_zone(ActiveSupport::TimeZone.new('Pacific Time (US & Canada)'))
+            end
+          I18n.l(d).strftime('%Y-%m-%d %I:%M%p')
+        rescue StandardError
+          d = datetime.is_a?(Time) ? datetime : Time.parse(datetime.to_s)
+          d.strftime('%Y-%m-%d %I:%M%p')
+        end
+      end
+    end
+  end
+end

--- a/spec/workflow/client/status_spec.rb
+++ b/spec/workflow/client/status_spec.rb
@@ -1,0 +1,181 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Dor::Workflow::Client::Status do
+  subject(:instance) do
+    described_class.new(druid: druid, version: version, lifecycle_routes: lifecycle_routes)
+  end
+  let(:druid) { 'druid:ab123cd4567' }
+  let(:version) { '2' }
+  let(:lifecycle_routes) { Dor::Workflow::Client::LifecycleRoutes.new(requestor: requestor) }
+  let(:requestor) { instance_double(Dor::Workflow::Client::Requestor, request: xml) }
+
+  describe '#display' do
+    subject(:status) { instance.display }
+
+    before do
+      # TODO: this stub is too knowledgable about the inner workings of the LifecycleRoutest
+      # instead it should just stub :milestones which returns an array of hashes
+      # expect(lifecycle_routes).to receive(:query_lifecycle).and_return(xml)
+    end
+
+    context 'for gv054hp4128' do
+      context 'when current version is published, but does not have a version attribute' do
+        let(:xml) do
+          '<?xml version="1.0" encoding="UTF-8"?>
+          <lifecycle objectId="druid:gv054hp4128">
+          <milestone date="2012-11-06T16:19:15-0800" version="2">described</milestone>
+          <milestone date="2012-11-06T16:21:02-0800">opened</milestone>
+          <milestone date="2012-11-06T16:30:03-0800">submitted</milestone>
+          <milestone date="2012-11-06T16:35:00-0800">described</milestone>
+          <milestone date="2012-11-06T16:59:39-0800" version="3">published</milestone>
+          <milestone date="2012-11-06T16:59:39-0800">published</milestone>
+          </lifecycle>'
+        end
+
+        let(:version) { '4' }
+
+        it 'generates a status string' do
+          expect(status).to eq('v4 In accessioning (described, published)')
+        end
+      end
+
+      context 'when current version matches the attribute in the milestone' do
+        let(:xml) do
+          '<?xml version="1.0" encoding="UTF-8"?>
+          <lifecycle objectId="druid:gv054hp4128">
+          <milestone date="2012-11-06T16:19:15-0800" version="2">described</milestone>
+          <milestone date="2012-11-06T16:59:39-0800" version="3">published</milestone>
+          </lifecycle>'
+        end
+        let(:version) { '3' }
+
+        it 'generates a status string' do
+          expect(status).to eq('v3 In accessioning (described, published)')
+        end
+      end
+    end
+
+    context 'for bd504dj1946' do
+      let(:xml) do
+        '<?xml version="1.0"?>
+        <lifecycle objectId="druid:bd504dj1946">
+        <milestone date="2013-04-03T15:01:57-0700">registered</milestone>
+        <milestone date="2013-04-03T16:20:19-0700">digitized</milestone>
+        <milestone date="2013-04-16T14:18:20-0700" version="1">submitted</milestone>
+        <milestone date="2013-04-16T14:32:54-0700" version="1">described</milestone>
+        <milestone date="2013-04-16T14:55:10-0700" version="1">published</milestone>
+        <milestone date="2013-07-21T05:27:23-0700" version="1">deposited</milestone>
+        <milestone date="2013-07-21T05:28:09-0700" version="1">accessioned</milestone>
+        <milestone date="2013-08-15T11:59:16-0700" version="2">opened</milestone>
+        <milestone date="2013-10-01T12:01:07-0700" version="2">submitted</milestone>
+        <milestone date="2013-10-01T12:01:24-0700" version="2">described</milestone>
+        <milestone date="2013-10-01T12:05:38-0700" version="2">published</milestone>
+        <milestone date="2013-10-01T12:10:56-0700" version="2">deposited</milestone>
+        <milestone date="2013-10-01T12:11:10-0700" version="2">accessioned</milestone>
+        </lifecycle>'
+      end
+
+      it 'handles a v2 accessioned object' do
+        expect(status).to eq('v2 Accessioned')
+      end
+
+      context 'when there are no lifecycles for the current version, indicating malfunction in workflow' do
+        let(:version) { '3' }
+
+        it 'gives a status of unknown' do
+          expect(status).to eq('v3 Unknown Status')
+        end
+      end
+
+      context 'when time is requested' do
+        subject(:status) { instance.display(include_time: true) }
+
+        it 'includes a formatted date/time if one is requested' do
+          expect(status).to eq('v2 Accessioned 2013-10-01 07:11PM')
+        end
+      end
+    end
+
+    context 'for an accessioned step with the exact same timestamp as the deposited step' do
+      let(:xml) do
+        '<?xml version="1.0"?>
+        <lifecycle objectId="druid:bd504dj1946">
+        <milestone date="2013-04-03T15:01:57-0700">registered</milestone>
+        <milestone date="2013-04-03T16:20:19-0700">digitized</milestone>
+        <milestone date="2013-04-16T14:18:20-0700" version="1">submitted</milestone>
+        <milestone date="2013-04-16T14:32:54-0700" version="1">described</milestone>
+        <milestone date="2013-04-16T14:55:10-0700" version="1">published</milestone>
+        <milestone date="2013-07-21T05:27:23-0700" version="1">deposited</milestone>
+        <milestone date="2013-07-21T05:28:09-0700" version="1">accessioned</milestone>
+        <milestone date="2013-08-15T11:59:16-0700" version="2">opened</milestone>
+        <milestone date="2013-10-01T12:01:07-0700" version="2">submitted</milestone>
+        <milestone date="2013-10-01T12:01:24-0700" version="2">described</milestone>
+        <milestone date="2013-10-01T12:05:38-0700" version="2">published</milestone>
+        <milestone date="2013-10-01T12:10:56-0700" version="2">deposited</milestone>
+        <milestone date="2013-10-01T12:10:56-0700" version="2">accessioned</milestone>
+        </lifecycle>'
+      end
+
+      subject(:status) { instance.display(include_time: true) }
+
+      it 'has the correct status of accessioned (v2) object' do
+        expect(status).to eq('v2 Accessioned 2013-10-01 07:10PM')
+      end
+    end
+
+    context 'for an accessioned step with an ealier timestamp than the deposited step' do
+      let(:xml) do
+        '<?xml version="1.0"?>
+        <lifecycle objectId="druid:bd504dj1946">
+        <milestone date="2013-04-03T15:01:57-0700">registered</milestone>
+        <milestone date="2013-04-03T16:20:19-0700">digitized</milestone>
+        <milestone date="2013-04-16T14:18:20-0700" version="1">submitted</milestone>
+        <milestone date="2013-04-16T14:32:54-0700" version="1">described</milestone>
+        <milestone date="2013-04-16T14:55:10-0700" version="1">published</milestone>
+        <milestone date="2013-07-21T05:27:23-0700" version="1">deposited</milestone>
+        <milestone date="2013-07-21T05:28:09-0700" version="1">accessioned</milestone>
+        <milestone date="2013-08-15T11:59:16-0700" version="2">opened</milestone>
+        <milestone date="2013-10-01T12:01:07-0700" version="2">submitted</milestone>
+        <milestone date="2013-10-01T12:01:24-0700" version="2">described</milestone>
+        <milestone date="2013-10-01T12:05:38-0700" version="2">published</milestone>
+        <milestone date="2013-10-01T12:10:56-0700" version="2">deposited</milestone>
+        <milestone date="2013-09-01T12:10:56-0700" version="2">accessioned</milestone>
+        </lifecycle>'
+      end
+
+      subject(:status) { instance.display(include_time: true) }
+
+      it 'has the correct status of accessioned (v2) object' do
+        expect(status).to eq('v2 Accessioned 2013-09-01 07:10PM')
+      end
+    end
+
+    context 'for a deposited step for a non-accessioned object' do
+      let(:xml) do
+        '<?xml version="1.0"?>
+        <lifecycle objectId="druid:bd504dj1946">
+        <milestone date="2013-04-03T15:01:57-0700">registered</milestone>
+        <milestone date="2013-04-03T16:20:19-0700">digitized</milestone>
+        <milestone date="2013-04-16T14:18:20-0700" version="1">submitted</milestone>
+        <milestone date="2013-04-16T14:32:54-0700" version="1">described</milestone>
+        <milestone date="2013-04-16T14:55:10-0700" version="1">published</milestone>
+        <milestone date="2013-07-21T05:27:23-0700" version="1">deposited</milestone>
+        <milestone date="2013-07-21T05:28:09-0700" version="1">accessioned</milestone>
+        <milestone date="2013-08-15T11:59:16-0700" version="2">opened</milestone>
+        <milestone date="2013-10-01T12:01:07-0700" version="2">submitted</milestone>
+        <milestone date="2013-10-01T12:01:24-0700" version="2">described</milestone>
+        <milestone date="2013-10-01T12:05:38-0700" version="2">published</milestone>
+        <milestone date="2013-10-01T12:10:56-0700" version="2">deposited</milestone>
+        </lifecycle>'
+      end
+
+      subject(:status) { instance.display(include_time: true) }
+
+      it 'has the correct status of deposited (v2) object' do
+        expect(status).to eq('v2 In accessioning (described, published, deposited) 2013-10-01 07:10PM')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is extracted from dor-serivces Dor::StatusService, because it is about workflow, not the persisted models