### PR TITLE
A new status service should be returned on each invocation

### DIFF
--- a/lib/dor/workflow/client.rb
+++ b/lib/dor/workflow/client.rb
@@ -82,7 +82,7 @@ module Dor
       end
 
       def status(druid:, version:)
-        @status ||= Status.new(druid: druid, version: version, lifecycle_routes: lifecycle_routes)
+        Status.new(druid: druid, version: version, lifecycle_routes: lifecycle_routes)
       end
 
       private


### PR DESCRIPTION
Otherwise you pass a different druid, but the status service has the previously passed druid