### PR TITLE
Remove repo from lifecycle routes and milestones

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ client.update_status(druid: 'druid:bc123df4567',
 
 Show "milestones" for an object
 ```ruby
-client.milestones('dor', 'druid:gv054hp4128')
+client.milestones('druid:gv054hp4128')
 #=> [{version: '1', milestone: 'published'}]
 ```
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ client.update_status(druid: 'druid:bc123df4567',
 
 Show "milestones" for an object
 ```ruby
-client.milestones('druid:gv054hp4128')
+client.milestones(druid: 'druid:gv054hp4128')
 #=> [{version: '1', milestone: 'published'}]
 ```
 

--- a/lib/dor/workflow/client/lifecycle_routes.rb
+++ b/lib/dor/workflow/client/lifecycle_routes.rb
@@ -10,33 +10,31 @@ module Dor
         end
 
         # Returns the Date for a requested milestone from workflow lifecycle
-        # @param [String] repo repository name
         # @param [String] druid object id
         # @param [String] milestone_name the name of the milestone being queried for
         # @param [Number] version the version to query for
         # @param [Boolean] active_only (false) if true, return only lifecycle steps for versions that have all processes complete
         # @return [Time] when the milestone was achieved.  Returns nil if the milestone does not exist
         #
-        def lifecycle(repo, druid, milestone_name, version: nil, active_only: false)
-          filter_milestone(query_lifecycle(repo, druid, version: version, active_only: active_only), milestone_name)
+        def lifecycle(druid, milestone_name, version: nil, active_only: false)
+          filter_milestone(query_lifecycle(druid, version: version, active_only: active_only), milestone_name)
         end
 
         # Returns the Date for a requested milestone ONLY for the current version.
         # This is slow as the workflow server will query dor-services-app for the version.
         # A better approach is #lifecycle with the version tag.
-        # @param [String] repo repository name
         # @param [String] druid object id
         # @param [String] milestone_name the name of the milestone being queried for
         # @param [Number] version the version to query for
         # @return [Time] when the milestone was achieved.  Returns nil if the milestone does not exis
         #
-        def active_lifecycle(repo, druid, milestone_name, version: nil)
-          lifecycle(repo, druid, milestone_name, version: version, active_only: true)
+        def active_lifecycle(druid, milestone_name, version: nil)
+          lifecycle(druid, milestone_name, version: version, active_only: true)
         end
 
-        # @return [Array<Hash>]
-        def milestones(repo, druid)
-          doc = query_lifecycle(repo, druid, active_only: false)
+        # @return [Hash]
+        def milestones(druid)
+          doc = query_lifecycle(druid, active_only: false)
           doc.xpath('//lifecycle/milestone').collect do |node|
             { milestone: node.text, at: Time.parse(node['date']), version: node['version'] }
           end
@@ -51,7 +49,6 @@ module Dor
           Time.parse(milestone['date'])
         end
 
-        # @param [String] repo repository name
         # @param [String] druid object id
         # @param [Boolean] active_only (false) if true, return only lifecycle steps for versions that have all processes complete
         # @param [Number] version the version to query for
@@ -63,8 +60,8 @@ module Dor
         #     <milestone date="2010-06-15T16:08:58-0700">released</milestone>
         #   </lifecycle>
         #
-        def query_lifecycle(repo, druid, active_only:, version: nil)
-          req = "#{repo}/objects/#{druid}/lifecycle"
+        def query_lifecycle(druid, active_only:, version: nil)
+          req = "objects/#{druid}/lifecycle"
           params = []
           params << "version=#{version}" if version
           params << 'active-only=true' if active_only

--- a/lib/dor/workflow/client/lifecycle_routes.rb
+++ b/lib/dor/workflow/client/lifecycle_routes.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/AbcSize, Metrics/MethodLength
 module Dor
   module Workflow
     class Client
@@ -19,26 +18,17 @@ module Dor
         # @param [Boolean] active_only (false) if true, return only lifecycle steps for versions that have all processes complete
         # @return [Time] when the milestone was achieved.  Returns nil if the milestone does not exist
         #
+        # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
         def lifecycle(*args)
           case args.size
-          when 5
-            Deprecation.warn(self, 'you provided 5 args, but lifecycle now takes kwargs')
-            (repo, druid, milestone_name) = args[0..2]
-            version = args[3][:version]
-            active_only = args[4][:active_only]
           when 4
             Deprecation.warn(self, 'you provided 4 args, but lifecycle now takes kwargs')
             (repo, druid, milestone_name) = args[0..2]
             version = args[3][:version]
-            active_only = false
+            active_only = args[3][:active_only] || false
           when 3
             Deprecation.warn(self, 'you provided 3 args, but lifecycle now takes kwargs')
             (repo, druid, milestone_name) = args
-            version = nil
-            active_only = false
-          when 2
-            Deprecation.warn(self, 'you provided 2 args, but lifecycle now takes kwargs')
-            (druid, milestone_name) = args
             version = nil
             active_only = false
           when 1
@@ -47,15 +37,16 @@ module Dor
             druid = opts[:druid]
             milestone_name = opts[:milestone_name]
             version = opts[:version]
-            active_only = opts.key?(:active_only) ? opts[:active_only] : false
+            active_only = opts[:active_only] || false
           else
-            raise ArgumentError, 'wrong number of arguments, must be 1-5'
+            raise ArgumentError, 'wrong number of arguments, must be 1, or 3-5'
           end
 
           Deprecation.warn(self, 'passing the repo parameter to lifecycle is no longer necessary. This will raise an error in dor-workflow-client version 4') if repo
 
           filter_milestone(query_lifecycle(druid, version: version, active_only: active_only), milestone_name)
         end
+        # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 
         # Returns the Date for a requested milestone ONLY for the current version.
         # This is slow as the workflow server will query dor-services-app for the version.
@@ -65,6 +56,7 @@ module Dor
         # @param [Number] version the version to query for
         # @return [Time] when the milestone was achieved.  Returns nil if the milestone does not exis
         #
+        # rubocop:disable Metrics/MethodLength
         def active_lifecycle(*args)
           case args.size
           when 4
@@ -75,10 +67,6 @@ module Dor
             Deprecation.warn(self, 'you provided 3 args, but active_lifecycle now takes kwargs')
             (repo, druid, milestone_name) = args
             version = nil
-          when 2
-            Deprecation.warn(self, 'you provided 2 args, but active_lifecycle now takes kwargs')
-            (druid, milestone_name) = args
-            version = nil
           when 1
             opts = args.first
             repo = opts[:repo]
@@ -86,15 +74,17 @@ module Dor
             milestone_name = opts[:milestone_name]
             version = opts[:version]
           else
-            raise ArgumentError, 'wrong number of arguments, must be 1-4'
+            raise ArgumentError, 'wrong number of arguments, must be 1, 3, or 4'
           end
 
           Deprecation.warn(self, 'passing the repo parameter to active_lifecycle is no longer necessary. This will raise an error in dor-workflow-client version 4') if repo
 
           lifecycle(druid: druid, milestone_name: milestone_name, version: version, active_only: true)
         end
+        # rubocop:enable Metrics/MethodLength
 
         # @return [Array<Hash>]
+        # rubocop:disable Metrics/MethodLength
         def milestones(*args)
           case args.size
           when 2
@@ -103,7 +93,7 @@ module Dor
           when 1
             opts = args.first
             repo = opts[:repo]
-            druid = opts[:druid]
+            druid = opts.fetch(:druid)
           else
             raise ArgumentError, 'wrong number of arguments, must be 1-2'
           end
@@ -115,6 +105,7 @@ module Dor
             { milestone: node.text, at: Time.parse(node['date']), version: node['version'] }
           end
         end
+        # rubocop:enable Metrics/MethodLength
 
         private
 
@@ -151,4 +142,3 @@ module Dor
     end
   end
 end
-# rubocop:enable Metrics/AbcSize, Metrics/MethodLength

--- a/lib/dor/workflow/client/lifecycle_routes.rb
+++ b/lib/dor/workflow/client/lifecycle_routes.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# rubocop:disable Metrics/AbcSize, Metrics/MethodLength
 module Dor
   module Workflow
     class Client
@@ -10,13 +11,49 @@ module Dor
         end
 
         # Returns the Date for a requested milestone from workflow lifecycle
+        #
+        # @param [String] repo The repository the object resides in. This parameter is deprecated
         # @param [String] druid object id
         # @param [String] milestone_name the name of the milestone being queried for
         # @param [Number] version the version to query for
         # @param [Boolean] active_only (false) if true, return only lifecycle steps for versions that have all processes complete
         # @return [Time] when the milestone was achieved.  Returns nil if the milestone does not exist
         #
-        def lifecycle(druid, milestone_name, version: nil, active_only: false)
+        def lifecycle(*args)
+          case args.size
+          when 5
+            Deprecation.warn(self, 'you provided 5 args, but lifecycle now takes kwargs')
+            (repo, druid, milestone_name) = args[0..2]
+            version = args[3][:version]
+            active_only = args[4][:active_only]
+          when 4
+            Deprecation.warn(self, 'you provided 4 args, but lifecycle now takes kwargs')
+            (repo, druid, milestone_name) = args[0..2]
+            version = args[3][:version]
+            active_only = false
+          when 3
+            Deprecation.warn(self, 'you provided 3 args, but lifecycle now takes kwargs')
+            (repo, druid, milestone_name) = args
+            version = nil
+            active_only = false
+          when 2
+            Deprecation.warn(self, 'you provided 2 args, but lifecycle now takes kwargs')
+            (druid, milestone_name) = args
+            version = nil
+            active_only = false
+          when 1
+            opts = args.first
+            repo = opts[:repo]
+            druid = opts[:druid]
+            milestone_name = opts[:milestone_name]
+            version = opts[:version]
+            active_only = opts.key?(:active_only) ? opts[:active_only] : false
+          else
+            raise ArgumentError, 'wrong number of arguments, must be 1-5'
+          end
+
+          Deprecation.warn(self, 'passing the repo parameter to lifecycle is no longer necessary. This will raise an error in dor-workflow-client version 4') if repo
+
           filter_milestone(query_lifecycle(druid, version: version, active_only: active_only), milestone_name)
         end
 
@@ -28,12 +65,51 @@ module Dor
         # @param [Number] version the version to query for
         # @return [Time] when the milestone was achieved.  Returns nil if the milestone does not exis
         #
-        def active_lifecycle(druid, milestone_name, version: nil)
-          lifecycle(druid, milestone_name, version: version, active_only: true)
+        def active_lifecycle(*args)
+          case args.size
+          when 4
+            Deprecation.warn(self, 'you provided 4 args, but active_lifecycle now takes kwargs')
+            (repo, druid, milestone_name) = args[0..2]
+            version = args[3][:version]
+          when 3
+            Deprecation.warn(self, 'you provided 3 args, but active_lifecycle now takes kwargs')
+            (repo, druid, milestone_name) = args
+            version = nil
+          when 2
+            Deprecation.warn(self, 'you provided 2 args, but active_lifecycle now takes kwargs')
+            (druid, milestone_name) = args
+            version = nil
+          when 1
+            opts = args.first
+            repo = opts[:repo]
+            druid = opts[:druid]
+            milestone_name = opts[:milestone_name]
+            version = opts[:version]
+          else
+            raise ArgumentError, 'wrong number of arguments, must be 1-4'
+          end
+
+          Deprecation.warn(self, 'passing the repo parameter to active_lifecycle is no longer necessary. This will raise an error in dor-workflow-client version 4') if repo
+
+          lifecycle(druid: druid, milestone_name: milestone_name, version: version, active_only: true)
         end
 
-        # @return [Hash]
-        def milestones(druid)
+        # @return [Array<Hash>]
+        def milestones(*args)
+          case args.size
+          when 2
+            Deprecation.warn(self, 'you provided 2 args, but active_lifecycle now takes kwargs')
+            (repo, druid) = args
+          when 1
+            opts = args.first
+            repo = opts[:repo]
+            druid = opts[:druid]
+          else
+            raise ArgumentError, 'wrong number of arguments, must be 1-2'
+          end
+
+          Deprecation.warn(self, 'passing the repo parameter to active_lifecycle is no longer necessary. This will raise an error in dor-workflow-client version 4') if repo
+
           doc = query_lifecycle(druid, active_only: false)
           doc.xpath('//lifecycle/milestone').collect do |node|
             { milestone: node.text, at: Time.parse(node['date']), version: node['version'] }
@@ -75,3 +151,4 @@ module Dor
     end
   end
 end
+# rubocop:enable Metrics/AbcSize, Metrics/MethodLength

--- a/lib/dor/workflow/client/status.rb
+++ b/lib/dor/workflow/client/status.rb
@@ -86,7 +86,7 @@ module Dor
         end
 
         def milestones
-          @milestones ||= lifecycle_routes.milestones('dor', druid)
+          @milestones ||= lifecycle_routes.milestones(druid)
         end
 
         private

--- a/lib/dor/workflow/client/status.rb
+++ b/lib/dor/workflow/client/status.rb
@@ -86,7 +86,7 @@ module Dor
         end
 
         def milestones
-          @milestones ||= lifecycle_routes.milestones(druid)
+          @milestones ||= lifecycle_routes.milestones(druid: druid)
         end
 
         private

--- a/spec/workflow/client/lifecycle_routes_spec.rb
+++ b/spec/workflow/client/lifecycle_routes_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Dor::Workflow::Client::LifecycleRoutes do
       allow(routes).to receive(:query_lifecycle).and_return(ng_xml)
     end
 
-    subject(:milestones) { routes.milestones('dor', 'druid:gv054hp4128') }
+    subject(:milestones) { routes.milestones('druid:gv054hp4128') }
 
     it 'includes the version in with the milestones' do
       expect(milestones.first[:milestone]).to eq('published')
@@ -27,40 +27,40 @@ RSpec.describe Dor::Workflow::Client::LifecycleRoutes do
 
   describe '#lifecycle' do
     context 'without version' do
-      subject(:lifecycle) { routes.lifecycle('dor', 'druid:gv054hp4128', 'submitted') }
+      subject(:lifecycle) { routes.lifecycle('druid:gv054hp4128', 'submitted') }
 
       it 'make the request' do
         lifecycle
-        expect(requestor).to have_received(:request).with('dor/objects/druid:gv054hp4128/lifecycle')
+        expect(requestor).to have_received(:request).with('objects/druid:gv054hp4128/lifecycle')
       end
     end
 
     context 'with version' do
-      subject(:lifecycle) { routes.lifecycle('dor', 'druid:gv054hp4128', 'submitted', version: 3) }
+      subject(:lifecycle) { routes.lifecycle('druid:gv054hp4128', 'submitted', version: 3) }
 
       it 'makes the request with the version' do
         lifecycle
-        expect(requestor).to have_received(:request).with('dor/objects/druid:gv054hp4128/lifecycle?version=3')
+        expect(requestor).to have_received(:request).with('objects/druid:gv054hp4128/lifecycle?version=3')
       end
     end
   end
 
   describe '#active_lifecycle' do
     context 'without version' do
-      subject(:active_lifecycle) { routes.active_lifecycle('dor', 'druid:gv054hp4128', 'submitted') }
+      subject(:active_lifecycle) { routes.active_lifecycle('druid:gv054hp4128', 'submitted') }
 
       it 'make the request' do
         active_lifecycle
-        expect(requestor).to have_received(:request).with('dor/objects/druid:gv054hp4128/lifecycle?active-only=true')
+        expect(requestor).to have_received(:request).with('objects/druid:gv054hp4128/lifecycle?active-only=true')
       end
     end
 
     context 'with version' do
-      subject(:active_lifecycle) { routes.active_lifecycle('dor', 'druid:gv054hp4128', 'submitted', version: 3) }
+      subject(:active_lifecycle) { routes.active_lifecycle('druid:gv054hp4128', 'submitted', version: 3) }
 
       it 'makes the request with the version' do
         active_lifecycle
-        expect(requestor).to have_received(:request).with('dor/objects/druid:gv054hp4128/lifecycle?version=3&active-only=true')
+        expect(requestor).to have_received(:request).with('objects/druid:gv054hp4128/lifecycle?version=3&active-only=true')
       end
     end
   end

--- a/spec/workflow/client/lifecycle_routes_spec.rb
+++ b/spec/workflow/client/lifecycle_routes_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe Dor::Workflow::Client::LifecycleRoutes do
   let(:requestor) { instance_double(Dor::Workflow::Client::Requestor, request: response) }
   let(:response) { '<xml />' }
   let(:routes) { described_class.new(requestor: requestor) }
+  let(:repo) { 'dor' }
+  let(:druid) { 'druid:gv054hp4128' }
 
   describe '#milestones' do
     let(:ng_xml) { Nokogiri::XML(xml) }
@@ -15,52 +17,177 @@ RSpec.describe Dor::Workflow::Client::LifecycleRoutes do
 
     before do
       allow(routes).to receive(:query_lifecycle).and_return(ng_xml)
+      allow(Deprecation).to receive(:warn)
     end
 
-    subject(:milestones) { routes.milestones('druid:gv054hp4128') }
+    context 'with positional arguments' do
+      subject(:milestones) { routes.milestones(repo, druid) }
 
-    it 'includes the version in with the milestones' do
-      expect(milestones.first[:milestone]).to eq('published')
-      expect(milestones.first[:version]).to eq('2')
+      it 'includes the version in with the milestones' do
+        expect(milestones.first[:milestone]).to eq('published')
+        expect(milestones.first[:version]).to eq('2')
+        expect(Deprecation).to have_received(:warn).twice
+      end
+    end
+
+    context 'with kwargs' do
+      subject(:milestones) { routes.milestones(druid: druid) }
+
+      it 'includes the version in with the milestones' do
+        expect(milestones.first[:milestone]).to eq('published')
+        expect(milestones.first[:version]).to eq('2')
+      end
     end
   end
 
   describe '#lifecycle' do
-    context 'without version' do
-      subject(:lifecycle) { routes.lifecycle('druid:gv054hp4128', 'submitted') }
+    context 'with positional arguments' do
+      before do
+        allow(Deprecation).to receive(:warn)
+      end
 
-      it 'make the request' do
-        lifecycle
-        expect(requestor).to have_received(:request).with('objects/druid:gv054hp4128/lifecycle')
+      context 'without version' do
+        subject(:lifecycle) { routes.lifecycle(repo, druid, 'submitted') }
+
+        it 'make the request' do
+          lifecycle
+          expect(requestor).to have_received(:request).with('objects/druid:gv054hp4128/lifecycle')
+          expect(Deprecation).to have_received(:warn).twice
+        end
+      end
+
+      context 'with version' do
+        subject(:lifecycle) { routes.lifecycle(repo, druid, 'submitted', version: 3) }
+
+        it 'makes the request with the version' do
+          lifecycle
+          expect(requestor).to have_received(:request).with('objects/druid:gv054hp4128/lifecycle?version=3')
+          expect(Deprecation).to have_received(:warn).twice
+        end
       end
     end
 
-    context 'with version' do
-      subject(:lifecycle) { routes.lifecycle('druid:gv054hp4128', 'submitted', version: 3) }
+    context 'with kwargs' do
+      before do
+        allow(Deprecation).to receive(:warn)
+      end
 
-      it 'makes the request with the version' do
-        lifecycle
-        expect(requestor).to have_received(:request).with('objects/druid:gv054hp4128/lifecycle?version=3')
+      context 'with deprecated repo arg' do
+        context 'without version' do
+          subject(:lifecycle) { routes.lifecycle(repo: repo, druid: druid, milestone_name: 'submitted') }
+
+          it 'make the request' do
+            lifecycle
+            expect(requestor).to have_received(:request).with('objects/druid:gv054hp4128/lifecycle')
+            expect(Deprecation).to have_received(:warn)
+          end
+        end
+
+        context 'with version' do
+          subject(:lifecycle) { routes.lifecycle(repo: repo, druid: druid, milestone_name: 'submitted', version: 3) }
+
+          it 'makes the request with the version' do
+            lifecycle
+            expect(requestor).to have_received(:request).with('objects/druid:gv054hp4128/lifecycle?version=3')
+            expect(Deprecation).to have_received(:warn)
+          end
+        end
+      end
+
+      context 'without version' do
+        subject(:lifecycle) { routes.lifecycle(druid: druid, milestone_name: 'submitted') }
+
+        it 'make the request' do
+          lifecycle
+          expect(requestor).to have_received(:request).with('objects/druid:gv054hp4128/lifecycle')
+          expect(Deprecation).not_to have_received(:warn)
+        end
+      end
+
+      context 'with version' do
+        subject(:lifecycle) { routes.lifecycle(druid: druid, milestone_name: 'submitted', version: 3) }
+
+        it 'makes the request with the version' do
+          lifecycle
+          expect(requestor).to have_received(:request).with('objects/druid:gv054hp4128/lifecycle?version=3')
+          expect(Deprecation).not_to have_received(:warn)
+        end
       end
     end
   end
 
   describe '#active_lifecycle' do
-    context 'without version' do
-      subject(:active_lifecycle) { routes.active_lifecycle('druid:gv054hp4128', 'submitted') }
+    context 'with positional arguments' do
+      before do
+        allow(Deprecation).to receive(:warn)
+      end
 
-      it 'make the request' do
-        active_lifecycle
-        expect(requestor).to have_received(:request).with('objects/druid:gv054hp4128/lifecycle?active-only=true')
+      context 'without version' do
+        subject(:active_lifecycle) { routes.active_lifecycle(repo, druid, 'submitted') }
+
+        it 'make the request' do
+          active_lifecycle
+          expect(requestor).to have_received(:request).with('objects/druid:gv054hp4128/lifecycle?active-only=true')
+          expect(Deprecation).to have_received(:warn).twice
+        end
+      end
+
+      context 'with version' do
+        subject(:active_lifecycle) { routes.active_lifecycle(repo, druid, 'submitted', version: 3) }
+
+        it 'makes the request with the version' do
+          active_lifecycle
+          expect(requestor).to have_received(:request).with('objects/druid:gv054hp4128/lifecycle?version=3&active-only=true')
+          expect(Deprecation).to have_received(:warn).twice
+        end
       end
     end
 
-    context 'with version' do
-      subject(:active_lifecycle) { routes.active_lifecycle('druid:gv054hp4128', 'submitted', version: 3) }
+    context 'with kwargs' do
+      before do
+        allow(Deprecation).to receive(:warn)
+      end
 
-      it 'makes the request with the version' do
-        active_lifecycle
-        expect(requestor).to have_received(:request).with('objects/druid:gv054hp4128/lifecycle?version=3&active-only=true')
+      context 'with deprecated repo arg' do
+        context 'without version' do
+          subject(:active_lifecycle) { routes.active_lifecycle(repo: repo, druid: druid, milestone_name: 'submitted') }
+
+          it 'make the request' do
+            active_lifecycle
+            expect(requestor).to have_received(:request).with('objects/druid:gv054hp4128/lifecycle?active-only=true')
+            expect(Deprecation).to have_received(:warn)
+          end
+        end
+
+        context 'with version' do
+          subject(:active_lifecycle) { routes.active_lifecycle(repo: repo, druid: druid, milestone_name: 'submitted', version: 3) }
+
+          it 'makes the request with the version' do
+            active_lifecycle
+            expect(requestor).to have_received(:request).with('objects/druid:gv054hp4128/lifecycle?version=3&active-only=true')
+            expect(Deprecation).to have_received(:warn)
+          end
+        end
+      end
+
+      context 'without version' do
+        subject(:active_lifecycle) { routes.active_lifecycle(druid: druid, milestone_name: 'submitted') }
+
+        it 'make the request' do
+          active_lifecycle
+          expect(requestor).to have_received(:request).with('objects/druid:gv054hp4128/lifecycle?active-only=true')
+          expect(Deprecation).not_to have_received(:warn)
+        end
+      end
+
+      context 'with version' do
+        subject(:active_lifecycle) { routes.active_lifecycle(druid: druid, milestone_name: 'submitted', version: 3) }
+
+        it 'makes the request with the version' do
+          active_lifecycle
+          expect(requestor).to have_received(:request).with('objects/druid:gv054hp4128/lifecycle?version=3&active-only=true')
+          expect(Deprecation).not_to have_received(:warn)
+        end
       end
     end
   end

--- a/spec/workflow/client_spec.rb
+++ b/spec/workflow/client_spec.rb
@@ -488,7 +488,7 @@ RSpec.describe Dor::Workflow::Client do
   describe '#lifecycle' do
     let(:stubs) do
       Faraday::Adapter::Test::Stubs.new do |stub|
-        stub.get('dor/objects/druid:123/lifecycle') do |_env|
+        stub.get('objects/druid:123/lifecycle') do |_env|
           [200, {}, <<-EOXML]
             <lifecycle objectId="druid:ct011cv6501">
                 <milestone date="2010-04-27T11:34:17-0700">registered</milestone>
@@ -498,7 +498,7 @@ RSpec.describe Dor::Workflow::Client do
           EOXML
         end
 
-        stub.get('dor/objects/druid:abc/lifecycle') do |_env|
+        stub.get('objects/druid:abc/lifecycle') do |_env|
           [200, {}, <<-EOXML]
             <lifecycle />
           EOXML
@@ -507,18 +507,18 @@ RSpec.describe Dor::Workflow::Client do
     end
 
     it 'returns a Time object reprenting when the milestone was reached' do
-      expect(client.lifecycle('dor', 'druid:123', 'released').beginning_of_day).to eq(Time.parse('2010-06-15T16:08:58-0700').beginning_of_day)
+      expect(client.lifecycle('druid:123', 'released').beginning_of_day).to eq(Time.parse('2010-06-15T16:08:58-0700').beginning_of_day)
     end
 
     it "returns nil if the milestone hasn't been reached yet" do
-      expect(client.lifecycle('dor', 'druid:abc', 'inprocess')).to be_nil
+      expect(client.lifecycle('druid:abc', 'inprocess')).to be_nil
     end
   end
 
   describe '#active_lifecycle' do
     let(:stubs) do
       Faraday::Adapter::Test::Stubs.new do |stub|
-        stub.get("dor/objects/#{@druid}/lifecycle") do |_env|
+        stub.get("objects/#{@druid}/lifecycle") do |_env|
           [200, {}, <<-EOXML]
             <lifecycle objectId="#{@druid}">
                 <milestone date="2010-04-27T11:34:17-0700">registered</milestone>
@@ -528,7 +528,7 @@ RSpec.describe Dor::Workflow::Client do
           EOXML
         end
 
-        stub.get("dor/objects/#{@druid}/lifecycle") do |_env|
+        stub.get("objects/#{@druid}/lifecycle") do |_env|
           [200, {}, <<-EOXML]
             <lifecycle />
           EOXML
@@ -537,11 +537,11 @@ RSpec.describe Dor::Workflow::Client do
     end
 
     it 'parses out the active lifecycle' do
-      expect(client.active_lifecycle('dor', @druid, 'released').beginning_of_day).to eq(Time.parse('2010-06-15T16:08:58-0700').beginning_of_day)
+      expect(client.active_lifecycle(@druid, 'released').beginning_of_day).to eq(Time.parse('2010-06-15T16:08:58-0700').beginning_of_day)
     end
 
     it 'handles missing lifecycle' do
-      expect(client.active_lifecycle('dor', @druid, 'NOT_FOUND')).to be_nil
+      expect(client.active_lifecycle(@druid, 'NOT_FOUND')).to be_nil
     end
   end
 

--- a/spec/workflow/client_spec.rb
+++ b/spec/workflow/client_spec.rb
@@ -507,11 +507,11 @@ RSpec.describe Dor::Workflow::Client do
     end
 
     it 'returns a Time object reprenting when the milestone was reached' do
-      expect(client.lifecycle('druid:123', 'released').beginning_of_day).to eq(Time.parse('2010-06-15T16:08:58-0700').beginning_of_day)
+      expect(client.lifecycle(druid: 'druid:123', milestone_name: 'released').beginning_of_day).to eq(Time.parse('2010-06-15T16:08:58-0700').beginning_of_day)
     end
 
     it "returns nil if the milestone hasn't been reached yet" do
-      expect(client.lifecycle('druid:abc', 'inprocess')).to be_nil
+      expect(client.lifecycle(druid: 'druid:abc', milestone_name: 'inprocess')).to be_nil
     end
   end
 
@@ -537,11 +537,11 @@ RSpec.describe Dor::Workflow::Client do
     end
 
     it 'parses out the active lifecycle' do
-      expect(client.active_lifecycle(@druid, 'released').beginning_of_day).to eq(Time.parse('2010-06-15T16:08:58-0700').beginning_of_day)
+      expect(client.active_lifecycle(druid: @druid, milestone_name: 'released').beginning_of_day).to eq(Time.parse('2010-06-15T16:08:58-0700').beginning_of_day)
     end
 
     it 'handles missing lifecycle' do
-      expect(client.active_lifecycle(@druid, 'NOT_FOUND')).to be_nil
+      expect(client.active_lifecycle(druid: @druid, milestone_name: 'NOT_FOUND')).to be_nil
     end
   end
 


### PR DESCRIPTION
## Why was this change made?

Removes the repo parameter we're trying to deprecate from the lifecycle routes and milstones.

## Was the usage documentation (e.g. wiki, README) updated?

README

Note: I believe that argo is currently using the milestones out of solr, however it may need to be updated to get the appropriate lifecycle xml request. This should be tested in stage.