### PR TITLE
Pass the object version when deleting a workflow

### DIFF
--- a/lib/dor/workflow/client/workflow_routes.rb
+++ b/lib/dor/workflow/client/workflow_routes.rb
@@ -278,9 +278,16 @@ module Dor
         # @param [String] repo The repository the object resides in.  The service recoginzes "dor" and "sdr" at the moment
         # @param [String] druid The id of the object to delete the workflow from
         # @param [String] workflow The name of the workflow to be deleted
+        # @param [Integer] version The version of the workflow to delete
         # @return [Boolean] always true
-        def delete_workflow(repo, druid, workflow)
-          requestor.request "#{repo}/objects/#{druid}/workflows/#{workflow}", 'delete'
+        def delete_workflow(repo, druid, workflow, version: nil)
+          qs_args = if version
+                      "?version=#{version}"
+                    else
+                      Deprecation.warn(self, 'Calling delete_workflow without passing version is deprecated and will result in an error in dor-workflow-client 4.0')
+                      ''
+                    end
+          requestor.request "#{repo}/objects/#{druid}/workflows/#{workflow}#{qs_args}", 'delete'
           true
         end
 

--- a/spec/workflow/client_spec.rb
+++ b/spec/workflow/client_spec.rb
@@ -723,17 +723,29 @@ RSpec.describe Dor::Workflow::Client do
   end
 
   describe '#delete_workflow' do
-    let(:url) { "/objects/#{@druid}/workflows/accessionWF" }
-
     let(:stubs) do
       Faraday::Adapter::Test::Stubs.new do |stub|
         stub.delete(url) { |_env| [202, {}, ''] }
       end
     end
 
-    it 'sends a delete request to the workflow service' do
-      expect(mock_http_connection).to receive(:delete).with(url).and_call_original
-      client.delete_workflow(nil, @druid, 'accessionWF')
+    context 'without a version' do
+      let(:url) { "/objects/#{@druid}/workflows/accessionWF" }
+
+      it 'sends a delete request to the workflow service' do
+        expect(Deprecation).to receive(:warn)
+        expect(mock_http_connection).to receive(:delete).with(url).and_call_original
+        client.delete_workflow(nil, @druid, 'accessionWF')
+      end
+    end
+
+    context 'with a version' do
+      let(:url) { "/objects/#{@druid}/workflows/accessionWF?version=5" }
+
+      it 'sends a delete request to the workflow service' do
+        expect(mock_http_connection).to receive(:delete).with(url).and_call_original
+        client.delete_workflow(nil, @druid, 'accessionWF', version: 5)
+      end
     end
   end
 


### PR DESCRIPTION
## Why was this change made?
This will allow Hydrus to pass a version, which will allow workflow-server-app to be decoupled from dor-services-app


