### PR TITLE
Allows status to accept a string or integer version.

### DIFF
--- a/lib/dor/workflow/client/status.rb
+++ b/lib/dor/workflow/client/status.rb
@@ -33,11 +33,11 @@ module Dor
         }.freeze
 
         # @param [String] druid the object identifier
-        # @param [String] version the version identifier
+        # @param [String|Integer] version the version identifier
         # @param [LifecycleRoutes] lifecycle_routes the lifecycle client
         def initialize(druid:, version:, lifecycle_routes:)
           @druid = druid
-          @version = version
+          @version = version.to_s
           @lifecycle_routes = lifecycle_routes
         end
 

--- a/spec/workflow/client/status_spec.rb
+++ b/spec/workflow/client/status_spec.rb
@@ -75,6 +75,14 @@ RSpec.describe Dor::Workflow::Client::Status do
         expect(status).to eq('v2 Accessioned')
       end
 
+      context 'when version is an integer' do
+        let(:version) { 2 }
+
+        it 'converts to a string' do
+          expect(status).to eq('v2 Accessioned')
+        end
+      end
+
       context 'when there are no lifecycles for the current version, indicating malfunction in workflow' do
         let(:version) { '3' }
 


### PR DESCRIPTION
closes #169

## Why was this change made?
Reduce confusion over the data type for version.


## How was this change tested?
Unit


## Which documentation and/or configurations were updated?
NA


