### PR TITLE
Relax activesupport dependency to include 7

### DIFF
--- a/dor-workflow-client.gemspec
+++ b/dor-workflow-client.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(spec)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'activesupport', '>= 3.2.1', '< 7'
+  gem.add_dependency 'activesupport', '>= 3.2.1', '< 8'
   gem.add_dependency 'deprecation', '>= 0.99.0'
   gem.add_dependency 'faraday', '>= 0.9.2', '< 2.0'
   gem.add_dependency 'faraday_middleware'


### PR DESCRIPTION
## Why was this change made?

Rails 7 was released.

## How was this change tested?



## Which documentation and/or configurations were updated?



