### PR TITLE
[HOLD] [MAJOR] Upgrade to faraday 2

### DIFF
--- a/dor-workflow-client.gemspec
+++ b/dor-workflow-client.gemspec
@@ -19,8 +19,9 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'activesupport', '>= 3.2.1', '< 8'
   gem.add_dependency 'deprecation', '>= 0.99.0'
-  gem.add_dependency 'faraday', '>= 0.9.2', '< 2.0'
-  gem.add_dependency 'faraday_middleware'
+  gem.add_dependency 'faraday', '~> 2.0'
+  gem.add_dependency 'faraday-retry'
+
   gem.add_dependency 'nokogiri', '~> 1.6'
   gem.add_dependency 'zeitwerk', '~> 2.1'
 

--- a/lib/dor/workflow/client.rb
+++ b/lib/dor/workflow/client.rb
@@ -5,6 +5,7 @@ require 'active_support/core_ext'
 require 'nokogiri'
 require 'zeitwerk'
 require 'faraday'
+require 'faraday/retry'
 require 'deprecation'
 
 loader = Zeitwerk::Loader.new

--- a/lib/dor/workflow/client/connection_factory.rb
+++ b/lib/dor/workflow/client/connection_factory.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'faraday_middleware'
-
 module Dor
   module Workflow
     class Client
@@ -21,7 +19,6 @@ module Dor
         def build_connection
           Faraday.new(url: url) do |faraday|
             faraday.use Faraday::Response::RaiseError # raise exceptions on 40x, 50x responses
-            faraday.use FaradayMiddleware::FollowRedirects, limit: 3
             faraday.options.params_encoder = Faraday::FlatParamsEncoder
             if timeout
               faraday.options.timeout = timeout
@@ -51,11 +48,11 @@ module Dor
         attr_reader :logger, :timeout, :url
 
         def retriable_methods
-          Faraday::Request::Retry::IDEMPOTENT_METHODS + [:post]
+          Faraday::Retry::Middleware::IDEMPOTENT_METHODS + [:post]
         end
 
         def retriable_exceptions
-          Faraday::Request::Retry::DEFAULT_EXCEPTIONS + [Faraday::ConnectionFailed]
+          Faraday::Retry::Middleware::DEFAULT_EXCEPTIONS + [Faraday::ConnectionFailed]
         end
 
         def retry_block


### PR DESCRIPTION
This drops the redirect ability, because faraday_middleware doesn't support faraday 2, but we don't actually use that capability: https://github.com/sul-dlss/workflow-server-rails/blob/main/app/controllers/workflows_controller.rb#L23-L26

## Why was this change made?



## How was this change tested?



## Which documentation and/or configurations were updated?



