### PR TITLE
[semver:minor] allow deleting using kwargs and the new path

### DIFF
--- a/lib/dor/workflow/client/workflow_routes.rb
+++ b/lib/dor/workflow/client/workflow_routes.rb
@@ -275,19 +275,29 @@ module Dor
         end
 
         # Deletes a workflow from a particular repository and druid. This is only used by Hydrus.
-        # @param [String] repo The repository the object resides in.  The service recoginzes "dor" and "sdr" at the moment
         # @param [String] druid The id of the object to delete the workflow from
         # @param [String] workflow The name of the workflow to be deleted
         # @param [Integer] version The version of the workflow to delete
         # @return [Boolean] always true
-        def delete_workflow(repo, druid, workflow, version: nil)
+        def delete_workflow(*args)
+          case args.length
+          when 3..4
+            Deprecation.warn(self, 'Calling delete_workflow with positional args is deprecated, use kwargs instead')
+            (_repo, druid, workflow, version_hash) = *args
+            version = version_hash && version_hash[:version]
+          when 1
+            opts = args.first
+            druid = opts[:druid]
+            workflow = opts[:workflow]
+            version = opts[:version]
+          end
           qs_args = if version
                       "?version=#{version}"
                     else
                       Deprecation.warn(self, 'Calling delete_workflow without passing version is deprecated and will result in an error in dor-workflow-client 4.0')
                       ''
                     end
-          requestor.request "#{repo}/objects/#{druid}/workflows/#{workflow}#{qs_args}", 'delete'
+          requestor.request "/objects/#{druid}/workflows/#{workflow}#{qs_args}", 'delete'
           true
         end
 

--- a/spec/workflow/client/workflow_routes_spec.rb
+++ b/spec/workflow/client/workflow_routes_spec.rb
@@ -147,6 +147,19 @@ RSpec.describe Dor::Workflow::Client::WorkflowRoutes do
     end
   end
 
+  describe '#delete_all_workflows' do
+    subject(:delete_all_workflows) do
+      routes.delete_all_workflows(pid: 'druid:mw971zk1113')
+    end
+    let(:mock_requestor) { instance_double(Dor::Workflow::Client::Requestor, request: nil) }
+
+    it 'sends a delete request' do
+      delete_all_workflows
+      expect(mock_requestor).to have_received(:request)
+        .with('objects/druid:mw971zk1113/workflows', 'delete')
+    end
+  end
+
   describe '#all_workflows' do
     let(:xml) do
       <<~XML

--- a/spec/workflow/client_spec.rb
+++ b/spec/workflow/client_spec.rb
@@ -729,22 +729,34 @@ RSpec.describe Dor::Workflow::Client do
       end
     end
 
-    context 'without a version' do
-      let(:url) { "/objects/#{@druid}/workflows/accessionWF" }
+    context 'with positional args' do
+      context 'without a version' do
+        let(:url) { "/objects/#{@druid}/workflows/accessionWF" }
 
-      it 'sends a delete request to the workflow service' do
-        expect(Deprecation).to receive(:warn)
-        expect(mock_http_connection).to receive(:delete).with(url).and_call_original
-        client.delete_workflow(nil, @druid, 'accessionWF')
+        it 'sends a delete request to the workflow service' do
+          expect(Deprecation).to receive(:warn).twice
+          expect(mock_http_connection).to receive(:delete).with(url).and_call_original
+          client.delete_workflow(nil, @druid, 'accessionWF')
+        end
+      end
+
+      context 'with a version' do
+        let(:url) { "/objects/#{@druid}/workflows/accessionWF?version=5" }
+
+        it 'sends a delete request to the workflow service' do
+          expect(Deprecation).to receive(:warn)
+          expect(mock_http_connection).to receive(:delete).with(url).and_call_original
+          client.delete_workflow(nil, @druid, 'accessionWF', version: 5)
+        end
       end
     end
 
-    context 'with a version' do
+    context 'with kwargs' do
       let(:url) { "/objects/#{@druid}/workflows/accessionWF?version=5" }
 
       it 'sends a delete request to the workflow service' do
         expect(mock_http_connection).to receive(:delete).with(url).and_call_original
-        client.delete_workflow(nil, @druid, 'accessionWF', version: 5)
+        client.delete_workflow(druid: @druid, workflow: 'accessionWF', version: 5)
       end
     end
   end


### PR DESCRIPTION


## Why was this change made? 🤔
The new path doesn't have a repository in the url. See https://github.com/sul-dlss/workflow-server-rails/pull/562

Most of the other public methods prefer to be called with kwargs, so standardize on that.


## How was this change tested? 🤨
test suite.