### PR TITLE
Pin to faraday-retry 1.0

### DIFF
--- a/dor-workflow-client.gemspec
+++ b/dor-workflow-client.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'activesupport', '>= 3.2.1', '< 8'
   gem.add_dependency 'deprecation', '>= 0.99.0'
   gem.add_dependency 'faraday', '~> 2.0'
-  gem.add_dependency 'faraday-retry'
+  gem.add_dependency 'faraday-retry', '~> 1.0'
 
   gem.add_dependency 'nokogiri', '~> 1.6'
   gem.add_dependency 'zeitwerk', '~> 2.1'


### PR DESCRIPTION


## Why was this change made? 🤔

Because faraday-retry 2.0 was released and the code in this gem is not compatible with the new version

## How was this change tested? 🤨
Test suite



