### PR TITLE
require ruby 3.0 or higher

### DIFF
--- a/dor-workflow-client.gemspec
+++ b/dor-workflow-client.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
 
   gem.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   gem.require_paths = ['lib']
-  gem.required_ruby_version = '>= 2.7'
+  gem.required_ruby_version = '>= 3.0'
 
   gem.add_dependency 'activesupport', '>= 3.2.1', '< 8'
   gem.add_dependency 'deprecation', '>= 0.99.0'


### PR DESCRIPTION
## Why was this change made? 🤔

We use at least 3.0 everywhere now.

## How was this change tested? 🤨

⚡ ⚠ If this change affects the API or other fundamentals of this service, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** that exercise this service and/or test in [stage|qa] environment, in addition to specs. ⚡



