### PR TITLE
Adds completed_for? method to workflow response.

### DIFF
--- a/lib/dor/workflow/response/workflow.rb
+++ b/lib/dor/workflow/response/workflow.rb
@@ -17,6 +17,7 @@ module Dor
           workflow['id']
         end
 
+        # Check if there are any processes for the provided version.
         # @param [Integer] version the version we are checking for.
         def active_for?(version:)
           result = ng_xml.at_xpath("/workflow/process[@version=#{version}]")
@@ -35,8 +36,14 @@ module Dor
           ng_xml.xpath('/workflow/process').empty?
         end
 
-        def complete?
+        # Check if all processes are skipped or complete for the provided version.
+        # @param [Integer] version the version we are checking for.
+        def complete_for?(version:)
           ng_xml.xpath("/workflow/process[@version=#{version}]/@status").map(&:value).all? { |p| %w[skipped completed].include?(p) }
+        end
+
+        def complete?
+          complete_for?(version: version)
         end
 
         attr_reader :xml

--- a/spec/dor/workflow/response/workflow_spec.rb
+++ b/spec/dor/workflow/response/workflow_spec.rb
@@ -61,6 +61,31 @@ RSpec.describe Dor::Workflow::Response::Workflow do
     end
   end
 
+  describe '#complete_for?' do
+    let(:xml) do
+      <<~XML
+        <workflow repository="dor" objectId="druid:mw971zk1113" id="assemblyWF">
+          <process version="1" laneId="default" elapsed="0.0" attempts="1" datetime="2013-02-18T14:40:25-0800" status="completed" name="start-assembly"/>
+          <process version="1" laneId="default" elapsed="0.509" attempts="1" datetime="2013-02-18T14:42:24-0800" status="waiting" name="jp2-create"/>
+          <process version="2" laneId="default" elapsed="0.0" attempts="1" datetime="2013-02-18T14:40:25-0800" status="completed" name="start-assembly"/>
+          <process version="2" laneId="default" elapsed="0.509" attempts="1" datetime="2013-02-18T14:42:24-0800" status="completed" name="jp2-create"/>
+        </workflow>
+      XML
+    end
+
+    context 'when all steps are complete' do
+      it 'returns true' do
+        expect(instance.complete_for?(version: 2)).to be true
+      end
+    end
+
+    context 'when some steps are not complete' do
+      it 'returns false' do
+        expect(instance.complete_for?(version: 1)).to be false
+      end
+    end
+  end
+
   describe '#active_for?' do
     subject { instance.active_for?(version: 2) }
 


### PR DESCRIPTION
## Why was this change made? 🤔
So that the status of a workflow can be determined for a specific version.


## How was this change tested? 🤨

⚡ ⚠ If this change affects the API or other fundamentals of this service, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** that exercise this service and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit