### PR TITLE
Deprecate 'described' lifecycle milestone

### DIFF
--- a/lib/dor/workflow/client/status.rb
+++ b/lib/dor/workflow/client/status.rb
@@ -10,26 +10,24 @@ module Dor
           0 => 'Unknown Status', # if there are no milestones for the current version, someone likely messed up the versioning process.
           1 => 'Registered',
           2 => 'In accessioning',
-          3 => 'In accessioning (described)',
-          4 => 'In accessioning (described, published)',
-          5 => 'In accessioning (described, published, deposited)',
-          6 => 'Accessioned',
-          7 => 'Accessioned (indexed)',
-          8 => 'Accessioned (indexed, ingested)',
-          9 => 'Opened'
+          3 => 'In accessioning (published)',
+          4 => 'In accessioning (published, deposited)',
+          5 => 'Accessioned',
+          6 => 'Accessioned (indexed)',
+          7 => 'Accessioned (indexed, ingested)',
+          8 => 'Opened'
         }.freeze
 
         # milestones from accessioning and the order they happen in
         STEPS = {
           'registered' => 1,
           'submitted' => 2,
-          'described' => 3,
-          'published' => 4,
-          'deposited' => 5,
-          'accessioned' => 6,
-          'indexed' => 7,
-          'shelved' => 8,
-          'opened' => 9
+          'published' => 3,
+          'deposited' => 4,
+          'accessioned' => 5,
+          'indexed' => 6,
+          'shelved' => 7,
+          'opened' => 8
         }.freeze
 
         attr_reader :status_code
@@ -78,7 +76,7 @@ module Dor
         end
 
         # @return [String] text translation of the status code, minus any trailing parenthetical explanation
-        # e.g. 'In accessioning (described)' and 'In accessioning (described, published)' both return 'In accessioning'
+        # e.g. 'Accessioned (indexed)' and 'Accessioned (indexed, ingested)', both return 'Accessioned'
         def simplified_status_code(display)
           display.gsub(/\(.*\)$/, '').strip
         end

--- a/spec/dor/workflow/client/status_spec.rb
+++ b/spec/dor/workflow/client/status_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Dor::Workflow::Client::Status do
         let(:version) { '4' }
 
         it 'generates a status string' do
-          expect(status).to eq('v4 In accessioning (described, published)')
+          expect(status).to eq('v4 In accessioning (published)')
         end
       end
 
@@ -47,7 +47,7 @@ RSpec.describe Dor::Workflow::Client::Status do
         let(:version) { '3' }
 
         it 'generates a status string' do
-          expect(status).to eq('v3 In accessioning (described, published)')
+          expect(status).to eq('v3 In accessioning (published)')
         end
       end
     end
@@ -177,7 +177,7 @@ RSpec.describe Dor::Workflow::Client::Status do
       end
 
       it 'has the correct status of deposited (v2) object' do
-        expect(status).to eq('v2 In accessioning (described, published, deposited) 2013-10-01 07:10PM')
+        expect(status).to eq('v2 In accessioning (published, deposited) 2013-10-01 07:10PM')
       end
     end
   end


### PR DESCRIPTION
## Why was this change made? 🤔
Goes with https://github.com/sul-dlss/argo/issues/4387 to no longer track or display a "described" milestone. 

## How was this change tested? 🤨
Unit.


