### PR TITLE
add metadata param for workflow variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+workflow_service.log
 .ruby-version
 .ruby-gemset

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
-workflow_service.log
-workflow_service.log.*
+workflow_service.log*
 .ruby-version
 .ruby-gemset

--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,6 @@ test/tmp
 test/version_tmp
 tmp
 workflow_service.log
+workflow_service.log.*
 .ruby-version
 .ruby-gemset

--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ Create a workflow
 client.create_workflow_by_name('druid:bc123df4567', 'etdSubmitWF', version: '1')
 ```
 
+Create a workflow and send in metadata
+```
+client.create_workflow_by_name('druid:bc123df4567', 'etdSubmitWF', version: '1', metadata: { foo: 'bar'} )
+```
+
 Update a workflow step's status
 ```ruby
 client.update_status(druid: 'druid:bc123df4567',

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Consumers of recent versions of the [dor-services](https://github.com/sul-dlss/d
 
 During development, you can test the gem locally on your laptop, hitting a local instance of workflow-server-rails via the console:
 
-```
+```ruby
 bin/console
 
 client = Dor::Workflow::Client.new(url: 'http://localhost:3000')
@@ -35,7 +35,7 @@ client.workflows('druid:bc123df4567')
 client.workflow(pid: 'druid:bc123df4567', workflow_name: 'accessionWF')
 => #<Dor::Workflow::Response::Workflow:0x0000000105c8b440
 
-client.workflow(pid: 'druid:bc123df4567', workflow_name: 'accessionWF').process_for_recent_version(name: 'start-accession').metadata
+client.process(pid: 'druid:bc123df4567', workflow_name: 'accessionWF', process: 'start-accession').metadata
  => {"requireOCR"=>true}
 
 client.all_workflows(pid: 'druid:bc123df4567')
@@ -76,13 +76,13 @@ client.workflow(pid: 'druid:bc123df4567', workflow_name: 'etdSubmitWF')
 
 Fetch information about a workflow step:
 ```ruby
-client.workflow(pid: 'druid:bc123df4567', workflow_name: 'etdSubmitWF').process_for_recent_version(name: 'registrar-approval')
+client.process(pid: 'druid:bc123df4567', workflow_name: 'etdSubmitWF', process: 'registrar-approval')
  => #<Dor::Workflow::Response::Process:0x000000010c505098
 ```
 
 Fetch metadata about a workflow step:
 ```ruby
-client.workflow(pid: 'druid:bc123df4567', workflow_name: 'etdSubmitWF').process_for_recent_version(name: 'registrar-approval').metadata
+client.process(pid: 'druid:bc123df4567', workflow_name: 'etdSubmitWF', process: 'registrar-approval').metadata
  => {"foo"=>"bar"}
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,20 @@ client = Dor::Workflow::Client.new(url: 'https://test-server.edu/workflow/')
 
 Consumers of recent versions of the [dor-services](https://github.com/sul-dlss/dor-services) gem can access the configured `Dor::Workflow::Client` object via `Dor::Config`.
 
+## Console
+
+During development, you can test the gem locally on your laptop, hitting a local instance of workflow-server-rails via the console:
+
+```
+bin/console
+
+client = Dor::Workflow::Client.new(url: 'http://localhost:3000')
+client.create_workflow_by_name('druid:bc123df4567', 'accessionWF', version: '1', metadata: { 'requireOCR' => true})
+client.workflows('druid:bc123df4567')
+client.workflow(pid: 'druid:bc123df4567', workflow_name: 'accessionWF')
+client.all_workflows(pid: 'druid:bc123df4567')
+```
+
 ## API
 [Rubydoc](https://www.rubydoc.info/github/sul-dlss/dor-workflow-client/main)
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,18 @@ bin/console
 
 client = Dor::Workflow::Client.new(url: 'http://localhost:3000')
 client.create_workflow_by_name('druid:bc123df4567', 'accessionWF', version: '1', metadata: { 'requireOCR' => true})
+
 client.workflows('druid:bc123df4567')
+ => ["accessionWF"]
+
 client.workflow(pid: 'druid:bc123df4567', workflow_name: 'accessionWF')
+=> #<Dor::Workflow::Response::Workflow:0x0000000105c8b440
+
+client.workflow(pid: 'druid:bc123df4567', workflow_name: 'accessionWF').process_for_recent_version(name: 'start-accession').metadata
+ => {"requireOCR"=>true}
+
 client.all_workflows(pid: 'druid:bc123df4567')
+=> #<Dor::Workflow::Response::Workflows:0x00000001055d29a0>.....
 ```
 
 ## API

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ During development, you can test the gem locally on your laptop, hitting a local
 bin/console
 
 client = Dor::Workflow::Client.new(url: 'http://localhost:3000')
-client.create_workflow_by_name('druid:bc123df4567', 'accessionWF', version: '1', metadata: { 'requireOCR' => true})
+client.create_workflow_by_name('druid:bc123df4567', 'accessionWF', version: '1', context: { 'requireOCR' => true})
 
 client.workflows('druid:bc123df4567')
  => ["accessionWF"]
@@ -35,7 +35,7 @@ client.workflows('druid:bc123df4567')
 client.workflow(pid: 'druid:bc123df4567', workflow_name: 'accessionWF')
 => #<Dor::Workflow::Response::Workflow:0x0000000105c8b440
 
-client.process(pid: 'druid:bc123df4567', workflow_name: 'accessionWF', process: 'start-accession').metadata
+client.process(pid: 'druid:bc123df4567', workflow_name: 'accessionWF', process: 'start-accession').context
  => {"requireOCR"=>true}
 
 client.all_workflows(pid: 'druid:bc123df4567')
@@ -47,7 +47,7 @@ client.all_workflows(pid: 'druid:bc123df4567')
 
 ### Workflow Variables
 
-If a workflow or workflows for a particular object require data to be persisted and available between steps, workflow variables can be set.  These are per object/version pair and thus available to any step in any workflow for a given version of an object once set.  Pass in a metadata variable as a Hash as shown in the example below.  The metadata will be returned as a hash when fetching workflows data for an object.
+If a workflow or workflows for a particular object require data to be persisted and available between steps, workflow variables can be set.  These are per object/version pair and thus available to any step in any workflow for a given version of an object once set.  Pass in a context variable as a Hash as shown in the example below.  The context will be returned as a hash when fetching workflows data for an object.
 
 ### Example usage
 Create a workflow
@@ -55,9 +55,9 @@ Create a workflow
 client.create_workflow_by_name('druid:bc123df4567', 'etdSubmitWF', version: '1')
 ```
 
-Create a workflow and send in metadata
+Create a workflow and send in context
 ```
-client.create_workflow_by_name('druid:bc123df4567', 'etdSubmitWF', version: '1', metadata: { foo: 'bar'} )
+client.create_workflow_by_name('druid:bc123df4567', 'etdSubmitWF', version: '1', context: { foo: 'bar'} )
 ```
 
 Update a workflow step's status
@@ -80,9 +80,9 @@ client.process(pid: 'druid:bc123df4567', workflow_name: 'etdSubmitWF', process: 
  => #<Dor::Workflow::Response::Process:0x000000010c505098
 ```
 
-Fetch metadata about a workflow step:
+Fetch version context about a workflow step:
 ```ruby
-client.process(pid: 'druid:bc123df4567', workflow_name: 'etdSubmitWF', process: 'registrar-approval').metadata
+client.process(pid: 'druid:bc123df4567', workflow_name: 'etdSubmitWF', process: 'registrar-approval').context
  => {"foo"=>"bar"}
 ```
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ client.all_workflows(pid: 'druid:bc123df4567')
 ## API
 [Rubydoc](https://www.rubydoc.info/github/sul-dlss/dor-workflow-client/main)
 
+### Workflow Variables
+
+If a workflow or workflows for a particular object require data to be persisted and available between steps, workflow variables can be set.  These are per object/version pair and thus available to any step in any workflow for a given version of an object once set.  Pass in a metadata variable as a Hash as shown in the example below.  The metadata will be returned as a hash when fetching workflows data for an object.
+
 ### Example usage
 Create a workflow
 ```
@@ -62,6 +66,24 @@ client.update_status(druid: 'druid:bc123df4567',
                      workflow: 'etdSubmitWF',
                      process: 'registrar-approval',
                      status: 'completed')
+```
+
+Fetch information about a workflow:
+```ruby
+client.workflow(pid: 'druid:bc123df4567', workflow_name: 'etdSubmitWF')
+ => #<Dor::Workflow::Response::Workflow:0x000000010cb28588
+```
+
+Fetch information about a workflow step:
+```ruby
+client.workflow(pid: 'druid:bc123df4567', workflow_name: 'etdSubmitWF').process_for_recent_version(name: 'registrar-approval')
+ => #<Dor::Workflow::Response::Process:0x000000010c505098
+```
+
+Fetch metadata about a workflow step:
+```ruby
+client.workflow(pid: 'druid:bc123df4567', workflow_name: 'etdSubmitWF').process_for_recent_version(name: 'registrar-approval').metadata
+ => {"foo"=>"bar"}
 ```
 
 Show "milestones" for an object

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'bundler/setup'
+require 'dor/workflow/client'
+
+require 'irb'
+IRB.start(__FILE__)

--- a/lib/dor/workflow/client.rb
+++ b/lib/dor/workflow/client.rb
@@ -40,7 +40,7 @@ module Dor
         @requestor = Requestor.new(connection: connection || ConnectionFactory.build_connection(url, timeout: timeout, logger: logger))
       end
 
-      delegate :create_workflow_by_name, :workflow_status, :workflows,
+      delegate :create_workflow_by_name, :workflow_status, :workflows, :all_workflows,
                :workflow, :process, :delete_workflow, :delete_all_workflows, :update_status, :update_error_status,
                to: :workflow_routes
 

--- a/lib/dor/workflow/client/lifecycle_routes.rb
+++ b/lib/dor/workflow/client/lifecycle_routes.rb
@@ -11,7 +11,6 @@ module Dor
 
         # Returns the Date for a requested milestone from workflow lifecycle
         #
-        # @param [String] repo The repository the object resides in. This parameter is deprecated
         # @param [String] druid object id
         # @param [String] milestone_name the name of the milestone being queried for
         # @param [Number] version (nil) the version to query for

--- a/lib/dor/workflow/client/version_routes.rb
+++ b/lib/dor/workflow/client/version_routes.rb
@@ -14,7 +14,6 @@ module Dor
         # - completes the versioningWF:submit-version and versioningWF:start-accession steps
         # - initiates accesssionWF
         #
-        # @param [String] repo The repository the object resides in. This parameter is deprecated
         # @param [String] druid The id of the object to delete the workflow from
         # @param [Boolean] create_accession_wf Option to create accessionWF when closing a version.  Defaults to true
         def close_version(druid:, version:, create_accession_wf: true)

--- a/lib/dor/workflow/client/workflow_routes.rb
+++ b/lib/dor/workflow/client/workflow_routes.rb
@@ -17,15 +17,15 @@ module Dor
         # @param [String] workflow_name The name of the workflow you want to create. This must correspond with a workflow
         # name that is known by the workflow service.
         # @param [String] lane_id adds laneId attribute to all process elements in the wf_xml workflow xml.  Defaults to a value of 'default'
-        # @param [Hash] metadata optional metadata to be included in the workflow (same for all processes for a given druid/version pair)
+        # @param [Hash] context optional context to be included in the workflow (same for all processes for a given druid/version pair)
         # @param [Integer] version specifies the version so that workflow service doesn't need to query dor-services.
         # @return [Boolean] always true
         #
-        def create_workflow_by_name(druid, workflow_name, version:, lane_id: 'default', metadata: nil)
+        def create_workflow_by_name(druid, workflow_name, version:, lane_id: 'default', context: nil)
           params = { 'lane-id' => lane_id, 'version' => version }
-          params.merge!('metadata' => metadata.to_json) if metadata
-          requestor.request "objects/#{druid}/workflows/#{workflow_name}", 'post', '',
-                            content_type: 'application/xml',
+          body = context ? { 'context' => context }.to_json : ''
+          requestor.request "objects/#{druid}/workflows/#{workflow_name}", 'post', body,
+                            content_type: 'application/json',
                             params: params
           true
         end

--- a/lib/dor/workflow/client/workflow_routes.rb
+++ b/lib/dor/workflow/client/workflow_routes.rb
@@ -33,7 +33,6 @@ module Dor
         # Updates the status of one step in a workflow.
         # Returns true on success.  Caller must handle any exceptions
         #
-        # @param [String] repo The repository the object resides in.  The service recoginzes "dor" and "sdr" at the moment
         # @param [String] druid The id of the object
         # @param [String] workflow The name of the workflow
         # @param [String] process The name of the process step
@@ -63,7 +62,6 @@ module Dor
 
         #
         # Retrieves the process status of the given workflow for the given object identifier
-        # @param [String] repo The repository the object resides in.  Currently recoginzes "dor" and "sdr".
         # @param [String] druid The id of the object
         # @param [String] workflow The name of the workflow
         # @param [String] process The name of the process step

--- a/lib/dor/workflow/client/workflow_routes.rb
+++ b/lib/dor/workflow/client/workflow_routes.rb
@@ -23,7 +23,7 @@ module Dor
         #
         def create_workflow_by_name(druid, workflow_name, version:, lane_id: 'default', metadata: nil)
           params = { 'lane-id' => lane_id, 'version' => version }
-          params.merge!('metadata' => metadata) if metadata
+          params.merge!('metadata' => metadata.to_json) if metadata
           requestor.request "objects/#{druid}/workflows/#{workflow_name}", 'post', '',
                             content_type: 'application/xml',
                             params: params

--- a/lib/dor/workflow/client/workflow_routes.rb
+++ b/lib/dor/workflow/client/workflow_routes.rb
@@ -17,11 +17,13 @@ module Dor
         # @param [String] workflow_name The name of the workflow you want to create. This must correspond with a workflow
         # name that is known by the workflow service.
         # @param [String] lane_id adds laneId attribute to all process elements in the wf_xml workflow xml.  Defaults to a value of 'default'
+        # @param [Hash] metadata optional metadata to be included in the workflow (same for all processes for a given druid/version pair)
         # @param [Integer] version specifies the version so that workflow service doesn't need to query dor-services.
         # @return [Boolean] always true
         #
-        def create_workflow_by_name(druid, workflow_name, version:, lane_id: 'default')
+        def create_workflow_by_name(druid, workflow_name, version:, lane_id: 'default', metadata: nil)
           params = { 'lane-id' => lane_id, 'version' => version }
+          params.merge!('metadata' => metadata) if metadata
           requestor.request "objects/#{druid}/workflows/#{workflow_name}", 'post', '',
                             content_type: 'application/xml',
                             params: params

--- a/lib/dor/workflow/response/process.rb
+++ b/lib/dor/workflow/response/process.rb
@@ -51,6 +51,13 @@ module Dor
           @attributes[:laneId].presence
         end
 
+        # @return [Hash] the metadata for the process (or nil if none present)
+        def metadata
+          return nil unless @attributes[:metadata].present?
+
+          JSON.parse(@attributes[:metadata])
+        end
+
         delegate :pid, :workflow_name, to: :parent
 
         private

--- a/lib/dor/workflow/response/process.rb
+++ b/lib/dor/workflow/response/process.rb
@@ -51,9 +51,9 @@ module Dor
           @attributes[:laneId].presence
         end
 
-        # @return [Hash] the context for the process (or nil if none present)
+        # @return [Hash] the context for the process (or empty hash if none present)
         def context
-          return nil unless @attributes[:context].present?
+          return {} unless @attributes[:context].present?
 
           JSON.parse(@attributes[:context])
         end

--- a/lib/dor/workflow/response/process.rb
+++ b/lib/dor/workflow/response/process.rb
@@ -51,11 +51,11 @@ module Dor
           @attributes[:laneId].presence
         end
 
-        # @return [Hash] the metadata for the process (or nil if none present)
-        def metadata
-          return nil unless @attributes[:metadata].present?
+        # @return [Hash] the context for the process (or nil if none present)
+        def context
+          return nil unless @attributes[:context].present?
 
-          JSON.parse(@attributes[:metadata])
+          JSON.parse(@attributes[:context])
         end
 
         delegate :pid, :workflow_name, to: :parent

--- a/spec/dor/workflow/client/workflow_routes_spec.rb
+++ b/spec/dor/workflow/client/workflow_routes_spec.rb
@@ -171,16 +171,16 @@ RSpec.describe Dor::Workflow::Client::WorkflowRoutes do
   describe '#create_workflow_by_name' do
     let(:mock_requestor) { instance_double(Dor::Workflow::Client::Requestor, request: nil) }
 
-    context 'with default lane_id and no metadata' do
+    context 'with default lane_id and no context' do
       subject(:create_workflow_by_name) do
         routes.create_workflow_by_name('druid:mw971zk1113', 'accessionWF', version: '1')
       end
 
-      it 'sends a create request with default lane_id and without any metadata param' do
+      it 'sends a create request with default lane_id and without any context param' do
         create_workflow_by_name
         expect(mock_requestor).to have_received(:request)
           .with('objects/druid:mw971zk1113/workflows/accessionWF', 'post', '',
-                { content_type: 'application/xml',
+                { content_type: 'application/json',
                   params: { 'lane-id' => 'default', 'version' => '1' } })
       end
     end
@@ -190,26 +190,26 @@ RSpec.describe Dor::Workflow::Client::WorkflowRoutes do
         routes.create_workflow_by_name('druid:mw971zk1113', 'accessionWF', version: '1', lane_id: 'hamburgers')
       end
 
-      it 'sends a create request without any metadata param' do
+      it 'sends a create request without any context param' do
         create_workflow_by_name
         expect(mock_requestor).to have_received(:request)
           .with('objects/druid:mw971zk1113/workflows/accessionWF', 'post', '',
-                { content_type: 'application/xml',
+                { content_type: 'application/json',
                   params: { 'lane-id' => 'hamburgers', 'version' => '1' } })
       end
     end
 
-    context 'when metadata is sent' do
+    context 'when context is sent' do
       subject(:create_workflow_by_name) do
-        routes.create_workflow_by_name('druid:mw971zk1113', 'accessionWF', version: '1', lane_id: 'default', metadata: { foo: 'bar' })
+        routes.create_workflow_by_name('druid:mw971zk1113', 'accessionWF', version: '1', lane_id: 'default', context: { foo: 'bar' })
       end
 
-      it 'sends a create request with the metadata param' do
+      it 'sends a create request with the context in the body' do
         create_workflow_by_name
         expect(mock_requestor).to have_received(:request)
-          .with('objects/druid:mw971zk1113/workflows/accessionWF', 'post', '',
-                { content_type: 'application/xml',
-                  params: { 'lane-id' => 'default', 'version' => '1', 'metadata' => '{"foo":"bar"}' } })
+          .with('objects/druid:mw971zk1113/workflows/accessionWF', 'post', '{"context":{"foo":"bar"}}',
+                { content_type: 'application/json',
+                  params: { 'lane-id' => 'default', 'version' => '1' } })
       end
     end
   end

--- a/spec/dor/workflow/client/workflow_routes_spec.rb
+++ b/spec/dor/workflow/client/workflow_routes_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe Dor::Workflow::Client::WorkflowRoutes do
         expect(mock_requestor).to have_received(:request)
           .with('objects/druid:mw971zk1113/workflows/accessionWF', 'post', '',
                 { content_type: 'application/xml',
-                  params: { 'lane-id' => 'default', 'version' => '1', 'metadata' => { foo: 'bar' } } })
+                  params: { 'lane-id' => 'default', 'version' => '1', 'metadata' => '{"foo":"bar"}' } })
       end
     end
   end

--- a/spec/dor/workflow/client/workflow_routes_spec.rb
+++ b/spec/dor/workflow/client/workflow_routes_spec.rb
@@ -169,8 +169,48 @@ RSpec.describe Dor::Workflow::Client::WorkflowRoutes do
   end
 
   describe '#create_workflow_by_name' do
-    it 'need to write these specs', skip: 'need to write specs' do
-      # something
+    let(:mock_requestor) { instance_double(Dor::Workflow::Client::Requestor, request: nil) }
+
+    context 'with default lane_id and no metadata' do
+      subject(:create_workflow_by_name) do
+        routes.create_workflow_by_name('druid:mw971zk1113', 'accessionWF', version: '1')
+      end
+
+      it 'sends a create request with default lane_id and without any metadata param' do
+        create_workflow_by_name
+        expect(mock_requestor).to have_received(:request)
+          .with('objects/druid:mw971zk1113/workflows/accessionWF', 'post', '',
+                { content_type: 'application/xml',
+                  params: { 'lane-id' => 'default', 'version' => '1' } })
+      end
+    end
+
+    context 'with a custom lane_id' do
+      subject(:create_workflow_by_name) do
+        routes.create_workflow_by_name('druid:mw971zk1113', 'accessionWF', version: '1', lane_id: 'hamburgers')
+      end
+
+      it 'sends a create request without any metadata param' do
+        create_workflow_by_name
+        expect(mock_requestor).to have_received(:request)
+          .with('objects/druid:mw971zk1113/workflows/accessionWF', 'post', '',
+                { content_type: 'application/xml',
+                  params: { 'lane-id' => 'hamburgers', 'version' => '1' } })
+      end
+    end
+
+    context 'when metadata is sent' do
+      subject(:create_workflow_by_name) do
+        routes.create_workflow_by_name('druid:mw971zk1113', 'accessionWF', version: '1', lane_id: 'default', metadata: { foo: 'bar' })
+      end
+
+      it 'sends a create request with the metadata param' do
+        create_workflow_by_name
+        expect(mock_requestor).to have_received(:request)
+          .with('objects/druid:mw971zk1113/workflows/accessionWF', 'post', '',
+                { content_type: 'application/xml',
+                  params: { 'lane-id' => 'default', 'version' => '1', 'metadata' => { foo: 'bar' } } })
+      end
     end
   end
 end

--- a/spec/dor/workflow/client_spec.rb
+++ b/spec/dor/workflow/client_spec.rb
@@ -225,6 +225,29 @@ RSpec.describe Dor::Workflow::Client do
     end
   end
 
+  describe '#all_workflows' do
+    let(:xml) do
+      <<~XML
+        <workflows objectId="druid:123">
+          <workflow repository="dor" objectId="druid:123" id="accessionWF">
+            <process laneId="default" lifecycle="submitted" elapsed="0.0" attempts="1" datetime="2013-02-18T15:08:10-0800" status="completed" name="start-accession"/>
+          </workflow>
+        </workflows>
+      XML
+    end
+    let(:stubs) do
+      Faraday::Adapter::Test::Stubs.new do |stub|
+        stub.get("/objects/#{@druid}/workflows") do |_env|
+          [200, {}, xml]
+        end
+      end
+    end
+
+    it 'returns the workflow details associated with druid' do
+      expect(client.all_workflows(pid: @druid).xml).to eq(xml)
+    end
+  end
+
   describe '#lifecycle' do
     let(:stubs) do
       Faraday::Adapter::Test::Stubs.new do |stub|

--- a/spec/dor/workflow/response/process_spec.rb
+++ b/spec/dor/workflow/response/process_spec.rb
@@ -87,7 +87,7 @@ RSpec.describe Dor::Workflow::Response::Process do
         XML
       end
 
-      it { is_expected.to be_nil }
+      it { is_expected.to eq({}) }
     end
   end
 end

--- a/spec/dor/workflow/response/process_spec.rb
+++ b/spec/dor/workflow/response/process_spec.rb
@@ -63,14 +63,14 @@ RSpec.describe Dor::Workflow::Response::Process do
     it { is_expected.to eq 'default' }
   end
 
-  describe '#metadata' do
-    subject { instance.metadata }
+  describe '#context' do
+    subject { instance.context }
 
-    context 'when metadata exists' do
+    context 'when context exists' do
       let(:xml) do
         <<~XML
           <workflow repository="dor" objectId="druid:mw971zk1113" id="assemblyWF">
-            <process name="start-assembly" laneId="default" metadata="{&quot;requireOCR&quot;:true}">
+            <process name="start-assembly" laneId="default" context="{&quot;requireOCR&quot;:true}">
           </workflow>
         XML
       end
@@ -78,11 +78,11 @@ RSpec.describe Dor::Workflow::Response::Process do
       it { is_expected.to eq({ 'requireOCR' => true }) }
     end
 
-    context 'when no metadata exists' do
+    context 'when no context exists' do
       let(:xml) do
         <<~XML
           <workflow repository="dor" objectId="druid:mw971zk1113" id="assemblyWF">
-            <process name="start-assembly" laneId="default" metadata="">
+            <process name="start-assembly" laneId="default" context="">
           </workflow>
         XML
       end

--- a/spec/dor/workflow/response/process_spec.rb
+++ b/spec/dor/workflow/response/process_spec.rb
@@ -62,4 +62,32 @@ RSpec.describe Dor::Workflow::Response::Process do
 
     it { is_expected.to eq 'default' }
   end
+
+  describe '#metadata' do
+    subject { instance.metadata }
+
+    context 'when metadata exists' do
+      let(:xml) do
+        <<~XML
+          <workflow repository="dor" objectId="druid:mw971zk1113" id="assemblyWF">
+            <process name="start-assembly" laneId="default" metadata="{&quot;requireOCR&quot;:true}">
+          </workflow>
+        XML
+      end
+
+      it { is_expected.to eq({ 'requireOCR' => true }) }
+    end
+
+    context 'when no metadata exists' do
+      let(:xml) do
+        <<~XML
+          <workflow repository="dor" objectId="druid:mw971zk1113" id="assemblyWF">
+            <process name="start-assembly" laneId="default" metadata="">
+          </workflow>
+        XML
+      end
+
+      it { is_expected.to be_nil }
+    end
+  end
 end


### PR DESCRIPTION
## Why was this change made? 🤔

Fixes #298 

~~HOLD until workflow-server-rails changes are merged and deployed.~~

Allow the user to send in optional workflow metadata variables.

Note that the response from workflow-server-rails for workflows with metadata just adds to the existing XML.  We add a new method to parse out the metadata for any step into a hash for the consumer (it comes in via the XML response as JSON, which is what is stored in the workflow-server-rails database).

Requires sul-dlss/workflow-server-rails#745 to be released 

Also:
- add the ability to test gem on the console (we do this in other gems too)
- add the missing 'all_workflows' route to base client and a spec for it

## How was this change tested? 🤨

1. New specs
2. Tested on localhost against local workflow-server-rails running new workflow-server variables work