### PR TITLE
Adds support for getting incomplete processes from workflow response.

### DIFF
--- a/spec/dor/workflow/response/workflow_spec.rb
+++ b/spec/dor/workflow/response/workflow_spec.rb
@@ -198,4 +198,62 @@ RSpec.describe Dor::Workflow::Response::Workflow do
       end
     end
   end
+
+  describe '#incomplete_processes' do
+    subject(:processes) { instance.incomplete_processes }
+
+    context 'when all steps are complete' do
+      let(:xml) do
+        <<~XML
+          <workflow repository="dor" objectId="druid:mw971zk1113" id="assemblyWF">
+            <process version="1" laneId="default" elapsed="0.0" attempts="1" datetime="2013-02-18T14:40:25-0800" status="completed" name="start-assembly"/>
+            <process version="1" laneId="default" elapsed="0.509" attempts="1" datetime="2013-02-18T14:42:24-0800" status="completed" name="jp2-create"/>
+          </workflow>
+        XML
+      end
+
+      it { is_expected.to be_empty }
+    end
+
+    context 'when some steps are not complete' do
+      let(:xml) do
+        <<~XML
+          <workflow repository="dor" objectId="druid:mw971zk1113" id="assemblyWF">
+            <process version="1" laneId="default" elapsed="0.0" attempts="1" datetime="2013-02-18T14:40:25-0800" status="completed" name="start-assembly"/>
+            <process version="1" laneId="default" elapsed="0.509" attempts="1" datetime="2013-02-18T14:42:24-0800" status="waiting" name="jp2-create"/>
+          </workflow>
+        XML
+      end
+
+      it 'returns the incomplete processes' do
+        expect(processes.size).to eq 1
+        expect(processes.first.name).to eq 'jp2-create'
+      end
+    end
+  end
+
+  describe '#incomplete_processes_for' do
+    let(:xml) do
+      <<~XML
+        <workflow repository="dor" objectId="druid:mw971zk1113" id="assemblyWF">
+          <process version="1" laneId="default" elapsed="0.0" attempts="1" datetime="2013-02-18T14:40:25-0800" status="completed" name="start-assembly"/>
+          <process version="1" laneId="default" elapsed="0.509" attempts="1" datetime="2013-02-18T14:42:24-0800" status="waiting" name="jp2-create"/>
+          <process version="2" laneId="default" elapsed="0.0" attempts="1" datetime="2013-02-18T14:40:25-0800" status="completed" name="start-assembly"/>
+          <process version="2" laneId="default" elapsed="0.509" attempts="1" datetime="2013-02-18T14:42:24-0800" status="completed" name="jp2-create"/>
+        </workflow>
+      XML
+    end
+
+    context 'when all steps are complete' do
+      it 'returns empty' do
+        expect(instance.incomplete_processes_for(version: 2)).to be_empty
+      end
+    end
+
+    context 'when some steps are not complete' do
+      it 'returns false' do
+        expect(instance.incomplete_processes_for(version: 1).size).to eq 1
+      end
+    end
+  end
 end


### PR DESCRIPTION
refs https://github.com/sul-dlss/dor-services-app/issues/4851

## Why was this change made? 🤔
To allow getting incomplete processes so that VersionService can determine if workflows are done-enough.


## How was this change tested? 🤨

⚡ ⚠ If this change affects the API or other fundamentals of this service, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** that exercise this service and/or test in [stage|qa] environment, in addition to specs. ⚡

Unit

