### PR TITLE
update very outdated comment

### DIFF
--- a/lib/dor/workflow/client.rb
+++ b/lib/dor/workflow/client.rb
@@ -24,7 +24,7 @@ module Dor
     #
     # Create and update workflows
     class Client
-      # From Workflow Service's admin/Process.java
+      # From workflow-server-rails' app/models/workflow_step.rb
       VALID_STATUS = %w[waiting completed error queued skipped started].freeze
 
       attr_accessor :requestor


### PR DESCRIPTION
## Why was this change made? 🤔

the relevant code is now here: https://github.com/sul-dlss/workflow-server-rails/blob/d104a2f116b2852ced37358deae698a9697e4b95/app/models/workflow_step.rb#L9

java workflow service was retired in 2017 ☕ 

discovered while looking up relevant code for review of https://github.com/sul-dlss/lyber-core/pull/167


## How was this change tested? 🤨

n/a, comment update only

⚡ ⚠ If this change affects the API or other fundamentals of this service, ***run [integration tests](https://github.com/sul-dlss/infrastructure-integration-test)*** that exercise this service and/or test in [stage|qa] environment, in addition to specs. ⚡



