### PR TITLE
raise an error when setting an error status incorrectly

### DIFF
--- a/lib/dor/workflow/client/workflow_routes.rb
+++ b/lib/dor/workflow/client/workflow_routes.rb
@@ -51,6 +51,7 @@ module Dor
         def update_status(druid:, workflow:, process:, status:, elapsed: 0, lifecycle: nil, note: nil, current_status: nil)
           raise ArgumentError, "Unknown status value #{status}" unless VALID_STATUS.include?(status)
           raise ArgumentError, "Unknown current_status value #{current_status}" if current_status && !VALID_STATUS.include?(current_status)
+          raise ArgumentError, "Do not set status to 'error', use update_error_status method" if status == 'error'
 
           xml = create_process_xml(name: process, status: status, elapsed: elapsed, lifecycle: lifecycle, note: note)
           uri = "objects/#{druid}/workflows/#{workflow}/#{process}"

--- a/spec/dor/workflow/client/workflow_routes_spec.rb
+++ b/spec/dor/workflow/client/workflow_routes_spec.rb
@@ -108,6 +108,12 @@ RSpec.describe Dor::Workflow::Client::WorkflowRoutes do
         expect { routes.update_status(druid: druid, workflow: 'accessionWF', process: 'publish', status: 'NOT_VALID_STATUS') }.to raise_error(ArgumentError)
       end
     end
+
+    context 'when an error status is provided' do
+      it 'throws an exception' do
+        expect { routes.update_status(druid: druid, workflow: 'accessionWF', process: 'publish', status: 'error') }.to raise_error(ArgumentError)
+      end
+    end
   end
 
   describe '#update_error_status' do


### PR DESCRIPTION
## Why was this change made? 🤔

If you use the wrong dor-workflow-client method to set the error status, you will get the error message being put in the wrong place (in the note field, displays in green in argo, instead of the error field, displays in red).

In addition, we noticed that the queuing of steps doesn't seem to work correctly and allows the next step to proceed even when the previous is an error.  

This should prevent that from happening at the client level.

## How was this change tested? 🤨

Updated spec