### PR TITLE
Add endpoint for querying objects erroring at a given step

### DIFF
--- a/lib/dor/workflow/client.rb
+++ b/lib/dor/workflow/client.rb
@@ -46,8 +46,7 @@ module Dor
 
       delegate :lifecycle, :active_lifecycle, :milestones, to: :lifecycle_routes
 
-      delegate :lane_ids, :objects_for_workstep,
-               to: :queues
+      delegate :lane_ids, :objects_for_workstep, :objects_erroring_at_workstep, to: :queues
 
       def queues
         @queues ||= Queues.new(requestor: requestor)

--- a/lib/dor/workflow/client/queues.rb
+++ b/lib/dor/workflow/client/queues.rb
@@ -80,6 +80,25 @@ module Dor
           Nokogiri::XML(resp).xpath('//object[@id]').map { |n| n[:id] }
         end
 
+        # Returns a list of druids from the workflow service that meet the criteria
+        # of the passed in error param
+        #
+        # @see `#objects_for_workstep`
+        #
+        # @param [String] error name of the error step
+        # @param [Hash] options
+        # @param options  [String]  :default_workflow workflow to query for if not using the qualified format
+        # @option options [Integer] :limit maximum number of druids to return (nil for no limit)
+        # @return [Array<String>]  Array of druids
+        def objects_erroring_at_workstep(error, options = {})
+          uri_string = "workflow_queue?error=#{error}"
+          uri_string += "&limit=#{options[:limit].to_i}" if options[:limit]&.to_i&.positive?
+
+          resp = requestor.request uri_string
+
+          Nokogiri::XML(resp).xpath('//object[@id]').map { |n| n[:id] }
+        end
+
         private
 
         attr_reader :requestor


### PR DESCRIPTION
# Why was this change made?

So the ETD app has a way to retry catalog-status runs if Folio is borked.

# How was this change tested?

CI, and used successfully in stage.
